### PR TITLE
Adds Terraform EKS provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/container-escape/terraform/aws/.terraform.lock.hcl
+++ b/container-escape/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,162 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.9.0"
+  constraints = ">= 3.63.0, >= 4.9.0"
+  hashes = [
+    "h1:gx4ni9ZxacUusjZdfLmRVgoMVn1o3CVo0xklOQA2zA8=",
+    "zh:084b83aef3335ad4f5e4b8323c6fe43c1ff55e17a7647c6a5cad6af519f72b42",
+    "zh:132e47ce69f14de4523b84b213cedf7173398acda14245b1ffe7747aac50f050",
+    "zh:2068baef7dfce3613f3b4f27314175e971f8db68d9cde9ec30b5659f80c68c6c",
+    "zh:63c6f489683d5f1ac55e82a0df387143ed22701d5f22c109a4d5c9924dd4e437",
+    "zh:8115fd21965954fa4568c09331e05bb29da967fab8d077419aed09954378e216",
+    "zh:8efdc95fde108f777ed9c79ae25dc17aea9771903250f5c5c8a4c726b90a345f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d42a7bc34d84b70c1d1bcc215cabd63abbcbd0352b70bd84da6c3916634932f",
+    "zh:aacbcceb241aa475888c0869e87593182edeced3170c76a0c960dd9c905df449",
+    "zh:c7fe7904511052e4102870256819a1917177572cf684f0611ebf767f9c1fbaa8",
+    "zh:c8e07c3424663d1d0e7e32f4ade8099c19f6326d37c6da98104d90c986ff66fc",
+    "zh:e47cafbd38b56ef14fd8d727b4ffea847c166b1c684f585ee5fb78983b537248",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.2.0"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:Id6dDkpuSSLbGPTdbw49bVS/7XXHu/+d7CJoGDqtk5g=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.10.0"
+  constraints = ">= 2.10.0"
+  hashes = [
+    "h1:/S01Zni8YzPN43XKQ57jOf1c5FrAlLCZ/MMr8k+nD4M=",
+    "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",
+    "zh:288ad46e240c5d1218909a9100ca8bd2197c8615558bbe7b393ba35877d5e4f0",
+    "zh:3e5554791ed103b6190efebe332fd3722796e6a59cf081f87ef1debb4e0b6ae3",
+    "zh:98e42cb48624be7eb2e16b5d8fc5044d7207943b6d13905bc3d3c006aa231cc7",
+    "zh:b1c800fd3971051d9deb4824f933e506ae288458e425be8ea449c9d40c7b0663",
+    "zh:bca1802585ecbc36bfcc700b6fa7c6ff96b2b8c4aca23c58df939a5002a05b4d",
+    "zh:c2f6bf46cd95d00f2bb1634afff92eeb269d27d83eea80b8cfceca1afdcd3033",
+    "zh:d2ccfbf3a9bf2ede8be6242c023173efd85a882cd3956a941f140c5718047412",
+    "zh:da19cd4a124f4ffc092e19f5b7a10ac4cce98db40cf855ea0d4a682f3df83a1f",
+    "zh:e3a2020453a86f80ad2b3f792e91a35fe272b907485a59c02d19269a1bdfe2fd",
+    "zh:f0659ca86e0dc0dd76b7f4497db8e58144ee9f0943b6d14dc57193d25ee22ced",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version     = "2.2.0"
+  constraints = "2.2.0"
+  hashes = [
+    "h1:RFAdqqzXo79YZNn/F9j1wFgfsoksIdGyFMUKDztyZqc=",
+    "zh:34618571b6eec4b9c951f638f0f752c2ea838eb141ebe1bd3cb41072205278ef",
+    "zh:51696c0562b8ef54e9c24d3911780cc2f3bb6fc57186489ebb54fdb4f6341e67",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7a1a5cb16db6ab407a4c77545b1ccf3d10940d497b7a9f4464616ceb7addb310",
+    "zh:7a95f80ac50cca758f363c480e4b54193a145fbd7c9393e575efeb6f33632224",
+    "zh:8152b95d97dde1cf9172168fe2930e53a37f850df052489adbe6dde29a533d7f",
+    "zh:8c5b1ae982731b7959f9d1e4ab8d3a8410cfd09d6f1298efaacd12e2c8ccdf11",
+    "zh:9882dc397c6374b366ea4a787658634838830e49dbe9da57707f05de2fa405b8",
+    "zh:aa386c3979e1460d9021fa46da13627b086523598b2290b9b43373c758300677",
+    "zh:aea377d457396ac08f6976fd7e2cc0242c49c031daca8b157a46070b7870755a",
+    "zh:e3e89280d0bb09ca2b7b29c0598eb594cd62933609f6b0d91c12fd1c72f04a01",
+    "zh:f427480d3ec953434eccf21544b0b2be63595634e4e79a53575ceb892f22230d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.0"
+  constraints = "3.1.0"
+  hashes = [
+    "h1:grYDj8/Lvp1OwME+g1AsECPN1czO5ssSf+8fCluCHQY=",
+    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
+    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
+    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
+    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
+    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
+    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
+    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
+    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
+    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
+    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
+    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.1.2"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:JF+aiOtS0G0ffbBdk1qfj7IrT39y/GZh/yl2IhqcIVM=",
+    "zh:0daceba867b330d3f8e2c5dc895c4291845a78f31955ce1b91ab2c4d1cd1c10b",
+    "zh:104050099efd30a630741f788f9576b19998e7a09347decbec3da0b21d64ba2d",
+    "zh:173f4ef3fdf0c7e2564a3db0fac560e9f5afdf6afd0b75d6646af6576b122b16",
+    "zh:41d50f975e535f968b3f37170fb07937c15b76d85ba947d0ce5e5ff9530eda65",
+    "zh:51a5038867e5e60757ed7f513dd6a973068241190d158a81d1b69296efb9cb8d",
+    "zh:6432a568e97a5a36cc8aebca5a7e9c879a55d3bc71d0da1ab849ad905f41c0be",
+    "zh:6bac6501394b87138a5e17c9f3a41e46ff7833ad0ba2a96197bb7787e95b641c",
+    "zh:6c0a7f5faacda644b022e7718e53f5868187435be6d000786d1ca05aa6683a25",
+    "zh:74c89de3fa6ef3027efe08f8473c2baeb41b4c6cee250ba7aeb5b64e8c79800d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b29eabbf0a5298f0e95a1df214c7cfe06ea9bcf362c63b3ad2f72d85da7d4685",
+    "zh:e891458c7a61e5b964e09616f1a4f87d0471feae1ec04cc51776e7dec1a3abce",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "3.3.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:oitTcxYGyDvHuNsjPJUi00a+AT0k+TWgNsGUSM2CV/E=",
+    "zh:16140e8cc880f95b642b6bf6564f4e98760e9991864aacc8e21273423571e561",
+    "zh:16338b8457759c97fdd73153965d6063b037f2954fd512e569fcdc42b7fef743",
+    "zh:348bd44b7cd0c6d663bba36cecb474c17635a8f22b02187d034b8e57a8729c5a",
+    "zh:3832ac73c2335c0fac26138bacbd18160efaa3f06c562869acc129e814e27f86",
+    "zh:756d1e60690d0164eee9c93b498b4c8beabbfc1d8b7346cb6d2fa719055089d6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:93b911bcddba8dadc5339edb004c8019c230ea67477c73c4f741c236dd9511b1",
+    "zh:c0c4e5742e8ac004c507540423db52af3f44b8ec04443aa8e14669340819344f",
+    "zh:c78296a1dff8ccd5d50203aac353422fc18d425072ba947c88cf5b46de7d32d2",
+    "zh:d7143f444e0f7e6cd67fcaf080398b4f1487cf05de3e0e79af6c14e22812e38b",
+    "zh:e600ac76b118816ad72132eee4c22ab5fc044f67c3babc54537e1fc1ad53d295",
+    "zh:fca07af5f591e12d2dc178a550da69a4847bdb34f8180a5b8e04fde6b528cf99",
+  ]
+}
+
+provider "registry.terraform.io/kreuzwerker/docker" {
+  version     = "2.16.0"
+  constraints = "2.16.0"
+  hashes = [
+    "h1:aslxshC6HTeDoZuygVzqDmyFCbCizZs7AWHDWk1p/6c=",
+    "zh:0ff8aa7884c6dae90e6f245bb9d37898735f89e095ba53413f2f364db4d11a77",
+    "zh:4101f4c909477f3a8225829b7063e5c5a2e2986a6163e0f113af040b5feab61f",
+    "zh:59db110d2b6c620cc12a1741d81ed8d1dd7fb0540024428fefbb57e8bebe5b60",
+    "zh:6e134983f195ea0273ac042f0a2df14158d676a24e8dd140ca0357f3efc3fd61",
+    "zh:7de1de3cc1eacb2ef2693207f5c5f54fa4814ae8c024b8b3c2a0923c82fd6f14",
+    "zh:a6659fbc7c45fbb60c7c9bf06724eb6084711f1b79c720ef8512a4367e63cbe5",
+    "zh:ae97c721431517d8c71f8cede91d734d2f2372a1bfef0c3bba43b54c0f8b1cee",
+    "zh:b3cbd47d5f0cb522b6dd3561ccd2f491fb6afb577372718e0663d12cfeef30e9",
+    "zh:b64af7c6ad8870c11677874f6cd13322aa03d2190391a120be17304ca324ea1c",
+    "zh:c363747bae968af997eaf22193168451523e92b59aee8aee135d3b27db132366",
+    "zh:c40721250642157b2a72d8db44fa09de0f7635ba4b0e2ebf5527570f3988e62f",
+    "zh:e97707609e346bf463d539099faa8790f2f453cfbd0b880327b6eae16ca4f213",
+    "zh:f4a23ce27cb430f91895466b3e2d132c534fa2b58808f6771235d76e696f4972",
+    "zh:fd634e973eb2b6483a1ce9251801a393d04cb496f8e83ffcf3f0c4cad8c18f4c",
+  ]
+}

--- a/container-escape/terraform/aws/README.md
+++ b/container-escape/terraform/aws/README.md
@@ -1,0 +1,245 @@
+# DVWA EKS Provisioning
+
+This folder contains Terraform automation code to provision the following:
+
+- **AWS VPC**
+- **AWS EKS Cluster** - 2 worker managed nodes (m5.medium)
+- **Kali Linux AWS EC2 Instance** - Kali Linux for ethical hacking
+
+
+<!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
+
+<!-- code_chunk_output -->
+
+- [DVWA EKS Provisioning](#dvwa-eks-provisioning)
+    - [Prerequsites](#prerequsites)
+  - [Configuration](#configuration)
+    - [Example configuration](#example-configuration)
+  - [Provision the cluster](#provision-the-cluster)
+  - [Connect to the cluster](#connect-to-the-cluster)
+  - [Kali Linux](#kali-linux)
+
+<!-- /code_chunk_output -->
+
+
+
+### Prerequsites
+
+- [AWS Account](https://aws.amazon.com/free/)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) - `~> aws-cli/2.4.28`
+- [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) - `~> v1.0.5`
+- [AWS EC2 Key Pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html) - You should already have an AWS key pair created and uploaded to the region where you want to provision.
+
+## Configuration
+
+Before provisioning set the following environment variables:
+
+- `TF_VAR_region` - AWS region where you want to provision the cluster.
+- `TF_VAR_demo_name` - This is a prefix that will be applied to all provisioned resources (i.e. `your_name`).
+- `TF_VAR_ssh_key` - AWS EC2 key pair for Kali linux access.
+- `TF_VAR_publicIP` - IP address of your home network to be applied to the security group for the Kali linux instance.
+
+### Example configuration 
+
+Open a terminal and run the following commands:
+
+```bash
+export TF_VAR_region=us-east-1
+
+export TF_VAR_demo_name=my_demo
+
+export TF_VAR_ssh_key=aws_key
+
+export TF_VAR_publicIP="73.231.132.25"
+```
+
+## Provision the cluster
+
+1. Clone the project
+```bash title="Clone the project"
+git clone git@github.com:mondoohq/demos.git
+```
+
+2. cd into the terraform folder
+```
+cd demos/container-escape/terraform/aws
+```
+
+3. Initialize the project (download modules)
+
+```
+terraform init
+```
+
+4. Check that everything is ready
+
+```
+terraform plan
+```
+
+5. Apply the configuration
+
+```
+terraform apply -auto-approve
+```
+
+Once the provisioning completes you will see something like this:
+
+```bash
+Apply complete! Resources: 81 added, 0 changed, 0 destroyed.
+
+Outputs:
+
+aws_auth_configmap_yaml = <<EOT
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - rolearn: arn:aws:iam::177043759486:role/scottford-dev-container-escape-demo-cc3c-iam-role
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+
+EOT
+cluster_arn = "arn:aws:eks:us-east-2:177043759486:cluster/scottford-dev-container-escape-demo-cc3c-cluster"
+cluster_certificate_authority_data = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1EUXhOVEF5TWpJeU9Gb1hEVE15TURReE1qQXlNakl5T0Zvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBUExiCnd0L3VFV242YW8wdHN5NDJFblAvUHhJNUdmWlc0Y1gyVEh3WWV0YzJ1RXJ2UjdySUZIRU5zVXZTVTVQRFphM2cKVHcza3pIK2VDV0ZWSllxa0s4c3pMV3NxVTUxSHpiejRyU1NHN3BFdGdHclZlbi9JZHhpelFTTEoyeVIxYlA0OQp1TC9uVU40MGRVK0ErZi8zdG5xQ3E3UnNGenljcVBEYmtla0VKMTNyNEFseG9PTThURHRqWlBTdlZpdE8vUGpyClJhR1JmaG5veXpMR1BGSEpJc2NwK2M3UFZIc2luL0dwM2wyNHFNczgyU1ZjT2h6TENhTjM5ZFZLbTZuUnFYeEEKUE5UZTdkNFFBNi9WRFh0YWIvMUVMTmlpcngvVHhLZFZTRW02bVlxMi9Cd1NySVdRQUV0bnFkditHd2YxZ1RCWgpYbmdFRE9yMi83TkN5WGcvRWxFQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZKa3ZwcmJuckVYanU5b2tINk9MN2xQZzU0eVVNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCNCtSUDVlZnJoVGZveXZWVTFqc2c2YU9lb2g5d3FpanlUczlNN3FJT0NJemNaNUorSgp5U3YzVnpCRHgyS01iR1hZT2QyMWY4STlUQVNycG42Z0IxVFdJTWFadWVCQThQcjlmVTRWRHA3UnN2dmxLVkZXCkkzdncvN2U4REhLZzN4dEk1OUM0aW4vOGRkSWkvSTdQRWZyVGNveDZMZUNmTjZlOU4yNllpZ0QrYmtaeW9IbXcKSlo1VVlmNGFIRlM3STJoWkMyWU1TUUpwZjN6L1B2b1lZOHFBTy9kMEN5eW8wQU5pQUVERHhyRHZuOU81L2RmQgphNDIxcklNNmYxek1yM1NpU1dwajJkZ1pST2xnTmduS05LaWNyUThSZDdpaHVlWnhXMkVRZlROdGplT3RwNE1ZCjZQU2VyUGFyS0txa0NJVERmdC9WV2gra2tHYTRsUnBtUnVDYQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg=="
+cluster_endpoint = "https://FCE158C9CB11823E921FE9C902A1BA67.gr7.us-east-2.eks.amazonaws.com"
+cluster_iam_role_arn = "arn:aws:iam::177043759486:role/eks-container-escape-cc3c"
+cluster_iam_role_name = "eks-container-escape-cc3c"
+cluster_iam_role_unique_id = "AROASSOFBMF7MTG4R7MGU"
+cluster_id = "scottford-dev-container-escape-demo-cc3c-cluster"
+cluster_name = "scottford-dev-container-escape-demo-cc3c-cluster"
+cluster_platform_version = "eks.6"
+cluster_primary_security_group_id = "sg-0eda416bd6bfc5e50"
+cluster_security_group_arn = "arn:aws:ec2:us-east-2:177043759486:security-group/sg-0d904bb4507c70571"
+cluster_security_group_id = "sg-0d904bb4507c70571"
+cluster_status = "ACTIVE"
+kali_linux_public_ip = "3.17.157.155"
+node_security_group_arn = "arn:aws:ec2:us-east-2:177043759486:security-group/sg-06df9685ecab6b2a0"
+node_security_group_id = "sg-06df9685ecab6b2a0"
+region = "us-east-2"
+```
+
+## Connect to the cluster
+
+After Terraform finishes provisioning, your local Kubeconfig is automatically updated to connect to your EKS cluster:
+
+```bash
+kubectl get nodes
+NAME                                       STATUS   ROLES    AGE     VERSION
+ip-10-0-5-7.us-east-2.compute.internal     Ready    <none>   6m14s   v1.21.5-eks-9017834
+ip-10-0-6-242.us-east-2.compute.internal   Ready    <none>   6m6s    v1.21.5-eks-9017834
+```
+
+```bash
+kubectl get deployments
+NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
+dvwa-container-escape   1/1     1            1           9m55s
+```
+
+```bash
+kubectl describe pods
+
+Name:         dvwa-container-escape-85c776c9bd-7cf4h
+Namespace:    default
+Priority:     0
+Node:         ip-10-0-5-7.us-east-2.compute.internal/10.0.5.7
+Start Time:   Thu, 14 Apr 2022 19:29:06 -0700
+Labels:       app=dvwa-container-escape
+              pod-template-hash=85c776c9bd
+Annotations:  kubernetes.io/psp: eks.privileged
+Status:       Running
+IP:           10.0.5.54
+IPs:
+  IP:           10.0.5.54
+Controlled By:  ReplicaSet/dvwa-container-escape-85c776c9bd
+Containers:
+  dvwa:
+    Container ID:   docker://d814f51104523b200d6c46dbb4c45d5fcc046adf26108f69a1fb48d0d0f9b573
+    Image:          public.ecr.aws/x6s5a8t7/dvwa:latest
+    Image ID:       docker-pullable://public.ecr.aws/x6s5a8t7/dvwa@sha256:8791eab52f1481d10e06bcd8a40188456ea3e5e4760e2f1407563c1e62e251f3
+    Port:           80/TCP
+    Host Port:      0/TCP
+    State:          Running
+      Started:      Thu, 14 Apr 2022 19:29:31 -0700
+    Ready:          True
+    Restart Count:  0
+    Environment:    <none>
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-cjv6n (ro)
+Conditions:
+  Type              Status
+  Initialized       True 
+  Ready             True 
+  ContainersReady   True 
+  PodScheduled      True 
+Volumes:
+  kube-api-access-cjv6n:
+    Type:                    Projected (a volume that contains injected data from multiple sources)
+    TokenExpirationSeconds:  3607
+    ConfigMapName:           kube-root-ca.crt
+    ConfigMapOptional:       <nil>
+    DownwardAPI:             true
+QoS Class:                   BestEffort
+Node-Selectors:              <none>
+Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
+Events:
+  Type     Reason            Age                  From               Message
+  ----     ------            ----                 ----               -------
+  Warning  FailedScheduling  8m25s (x4 over 10m)  default-scheduler  no nodes available to schedule pods
+  Warning  FailedScheduling  8m17s                default-scheduler  0/1 nodes are available: 1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
+  Warning  FailedScheduling  8m7s                 default-scheduler  0/2 nodes are available: 2 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate.
+  Normal   Scheduled         7m57s                default-scheduler  Successfully assigned default/dvwa-container-escape-85c776c9bd-7cf4h to ip-10-0-5-7.us-east-2.compute.internal
+  Normal   Pulling           7m56s                kubelet            Pulling image "public.ecr.aws/x6s5a8t7/dvwa:latest"
+  Normal   Pulled            7m34s                kubelet            Successfully pulled image "public.ecr.aws/x6s5a8t7/dvwa:latest" in 22.32723533s
+  Normal   Created           7m32s                kubelet            Created container dvwa
+  Normal   Started           7m32s                kubelet            Started container dvwa
+```
+
+## Kali Linux
+
+A Kali Linux EC2 instance is provisioned into the VPC for the hacking demo. Terraform will output the PublicIP address of the instance so you can SSH in.
+
+```bash
+kali_linux_public_ip = "3.133.152.115"
+```
+
+Use your AWS EC2 SSH key for access:
+
+```bash
+ssh -i ~/.ssh/aws_rsa kali@3.133.152.115
+The authenticity of host '3.133.152.115 (3.133.152.115)' can't be established.
+ED25519 key fingerprint is SHA256:e6U/A+r+nvGI3g3TD8ElB2uSmIvtXyx3wFoR9L1luBw.
+This key is not known by any other names
+Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
+Warning: Permanently added '3.133.152.115' (ED25519) to the list of known hosts.
+Linux kali 5.15.0-kali3-cloud-amd64 #1 SMP Debian 5.15.15-2kali1 (2022-01-31) x86_64
+
+The programs included with the Kali GNU/Linux system are free software;
+the exact distribution terms for each program are described in the
+individual files in /usr/share/doc/*/copyright.
+
+Kali GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
+permitted by applicable law.
+┏━(Message from Kali developers)
+┃
+┃ This is a cloud installation of Kali Linux. Learn more about
+┃ the specificities of the various cloud images:
+┃ ⇒ https://www.kali.org/docs/troubleshooting/common-cloud-setup/
+┃
+┗━(Run: “touch ~/.hushlogin” to hide this message)
+┌──(kali㉿kali)-[~]
+└─$ 
+```
+
+
+
+
+
+
+

--- a/container-escape/terraform/aws/deployment.tf
+++ b/container-escape/terraform/aws/deployment.tf
@@ -1,0 +1,42 @@
+resource "kubernetes_deployment_v1" "dvwa" {
+  depends_on = [
+    module.eks
+  ]
+  metadata {
+    name      = "dvwa-container-escape"
+    namespace = "default"
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        app = "dvwa-container-escape"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "dvwa-container-escape"
+        }
+      }
+
+      spec {
+        container {
+          image             = "public.ecr.aws/x6s5a8t7/dvwa:latest"
+          name              = "dvwa"
+          image_pull_policy = "IfNotPresent"
+
+          port {
+            container_port = "80"
+          }
+          security_context {
+            privileged = true
+          }
+        }
+
+        termination_grace_period_seconds = 30
+      }
+    }
+  }
+}

--- a/container-escape/terraform/aws/main.tf
+++ b/container-escape/terraform/aws/main.tf
@@ -1,0 +1,528 @@
+################################################################################
+# Data & Locals
+################################################################################
+
+data "aws_availability_zones" "available" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  name            = "${var.demo_name}-container-escape-demo-${random_string.suffix.result}"
+  cluster_version = var.kubernetes_version
+  # container_name  = "${aws_ecr_repository.dvwa.repository_url}:latest"
+  default_tags = {
+    Name       = local.name
+    GitHubRepo = "demo"
+    GitHubOrg  = "mondoohq"
+    Terraform  = true
+  }
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+################################################################################
+# ECR Repo Create & Docker Build & Push
+################################################################################
+
+# resource "aws_ecr_repository" "dvwa" {
+#   name = "dvwa-container-escape"
+# }
+
+# resource "null_resource" "ecr_login" {
+#   provisioner "local-exec" {
+#     command = "aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${aws_ecr_repository.dvwa.repository_url}"
+#   }
+# }
+
+# resource "docker_image" "dvwa" {
+#   name = "dvwa-container-escape"
+#   build {
+#     path = "${path.module}/../../dvwa-example"
+#     tag  = ["${aws_ecr_repository.dvwa.repository_url}:latest"]
+#   }
+# }
+
+# resource "null_resource" "docker_push" {
+#   provisioner "local-exec" {
+#     command = "docker push ${aws_ecr_repository.dvwa.repository_url}:latest"
+#   }
+# }
+
+################################################################################
+# VPC Configuration
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.14.0"
+
+  name                 = "${local.name}-vpc"
+  cidr                 = "10.0.0.0/16"
+  azs                  = data.aws_availability_zones.available.names
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  enable_flow_log                      = true
+  create_flow_log_cloudwatch_iam_role  = true
+  create_flow_log_cloudwatch_log_group = true
+
+  tags = merge(
+    local.default_tags, {
+      "Name"                                = "${local.name}-vpc"
+      "kubernetes.io/cluster/${local.name}" = "shared"
+    },
+  )
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/elb"              = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.name}" = "shared"
+    "kubernetes.io/role/internal-elb"     = "1"
+  }
+}
+
+
+################################################################################
+# EKS Module
+################################################################################
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 18.20.2"
+
+  cluster_name                    = "${local.name}-cluster"
+  cluster_version                 = local.cluster_version
+  cluster_endpoint_private_access = false
+  cluster_endpoint_public_access  = true
+
+  cluster_addons = {
+    coredns = {
+      resolve_conflicts = "OVERWRITE"
+    }
+    kube-proxy = {}
+    vpc-cni = {
+      resolve_conflicts = "OVERWRITE"
+    }
+  }
+
+  cluster_encryption_config = [{
+    provider_key_arn = aws_kms_key.eks.arn
+    resources        = ["secrets"]
+  }]
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  manage_aws_auth_configmap = true
+
+  # Extend cluster security group rules
+  cluster_security_group_additional_rules = {
+    egress_nodes_ephemeral_ports_tcp = {
+      description                = "To node 1025-65535"
+      protocol                   = "tcp"
+      from_port                  = 1025
+      to_port                    = 65535
+      type                       = "egress"
+      source_node_security_group = true
+    }
+  }
+
+  # Extend node-to-node security group rules
+  node_security_group_additional_rules = {
+    ingress_self_all = {
+      description = "Node to node all ports/protocols"
+      protocol    = "-1"
+      from_port   = 0
+      to_port     = 0
+      type        = "ingress"
+      self        = true
+    }
+    egress_all = {
+      description      = "Node all egress"
+      protocol         = "-1"
+      from_port        = 0
+      to_port          = 0
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    }
+  }
+
+  create_iam_role          = true
+  iam_role_name            = "eks-container-escape-${random_string.suffix.result}"
+  iam_role_use_name_prefix = false
+  iam_role_description     = "EKS role for container escape demo"
+  iam_role_tags = {
+    Purpose = "Protector of the kubelet"
+  }
+  iam_role_additional_policies = [
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  ]
+
+  eks_managed_node_group_defaults = {
+    ami_type       = "AL2_x86_64"
+    disk_size      = 80
+    instance_types = ["m5.large"]
+
+  }
+  eks_managed_node_groups = {
+    # Default node group - as provided by AWS EKS
+    # default_node_group = {
+    #   # By default, the module creates a launch template to ensure tags are propagated to instances, etc.,
+    #   # so we need to disable it to use the default template provided by the AWS EKS managed node group service
+    #   create_launch_template = false
+    #   launch_template_name   = ""
+
+    #   # Remote access cannot be specified with a launch template
+    #   remote_access = {
+    #     ec2_ssh_key               = var.ssh_key
+    #     source_security_group_ids = [aws_security_group.remote_access.id]
+    #   }
+    # }
+
+    # Complete
+    complete = {
+      name            = "complete-eks-mng"
+      use_name_prefix = true
+
+      subnet_ids = module.vpc.public_subnets
+
+      ami_type       = "AL2_x86_64"
+
+      min_size     = 2 
+      max_size     = 4
+      desired_size = 2
+
+      ami_id                     = data.aws_ami.eks_default.image_id
+      enable_bootstrap_user_data = true
+      bootstrap_extra_args       = "--kubelet-extra-args '--max-pods=20'"
+
+      pre_bootstrap_user_data = <<-EOT
+      export USE_MAX_PODS=false
+      EOT
+
+      post_bootstrap_user_data = <<-EOT
+      echo "you are free little kubelet!"
+      EOT
+
+      capacity_type        = "SPOT"
+      disk_size            = 80
+      force_update_version = true
+      instance_types       = ["m5.large", "m5n.large", "m5zn.large"]
+      labels = {
+        GithubRepo = "terraform-aws-eks"
+        GithubOrg  = "terraform-aws-modules"
+      }
+
+      update_config = {
+        max_unavailable_percentage = 50 # or set `max_unavailable`
+      }
+
+      description = "EKS managed node group"
+
+      ebs_optimized           = true
+      vpc_security_group_ids  = [aws_security_group.additional.id]
+      disable_api_termination = false
+      enable_monitoring       = true
+
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 80
+            volume_type           = "gp3"
+            iops                  = 3000
+            throughput            = 150
+            encrypted             = true
+            kms_key_id            = aws_kms_key.ebs.arn
+            delete_on_termination = true
+          }
+        }
+      }
+
+      create_iam_role          = true
+      iam_role_name            = "${local.name}-iam-role"
+      iam_role_use_name_prefix = false
+      iam_role_description     = "EKS managed node group role"
+      iam_role_tags = {
+        Purpose = "Protector of the kubelet"
+      }
+      iam_role_additional_policies = [
+        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+        "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+        "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+        "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+      ]
+
+      create_security_group          = true
+      security_group_name            = "${local.name}-managed-worker-sg"
+      security_group_use_name_prefix = false
+      security_group_description     = "EKS managed node group security group"
+      security_group_rules = {
+        phoneOut = {
+          description = "Hello CloudFlare"
+          protocol    = "udp"
+          from_port   = 53
+          to_port     = 53
+          type        = "egress"
+          cidr_blocks = ["1.1.1.1/32"]
+        }
+        phoneHome = {
+          description                   = "Hello cluster"
+          protocol                      = "udp"
+          from_port                     = 53
+          to_port                       = 53
+          type                          = "egress"
+          source_cluster_security_group = true # bit of reflection lookup
+        }
+      }
+      security_group_tags = {
+        Purpose = "Protector of the kubelet"
+      }
+
+      tags = {
+        ExtraTag = "EKS managed node group complete example"
+      }
+    }
+  }
+
+  tags = local.default_tags
+}
+
+
+
+
+################################################################################
+# Kali Linux Instance
+################################################################################
+
+data "aws_ami" "kali_linux" {
+  most_recent = true
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "name"
+    values = ["kali-linux-2022.*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+module "ec2_instance" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 3.0"
+
+  name = "${local.name}-kali-linux"
+
+  ami                    = data.aws_ami.kali_linux.id
+  instance_type          = "t2.medium"
+  key_name               = var.ssh_key
+  monitoring             = true
+  vpc_security_group_ids = [aws_security_group.kali_linux_access.id]
+  subnet_id              = element(module.vpc.public_subnets, 0)
+
+  tags = merge(
+    local.default_tags, {
+      "Name" = "kali-linux-hacker-instance-${random_string.suffix.result}"
+    },
+  )
+}
+
+resource "aws_security_group" "kali_linux_access" {
+  name_prefix = "kali_linux_access_${random_string.suffix.result}"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = [
+      "${var.publicIP}/32"
+    ]
+  }
+
+  tags = local.default_tags
+}
+
+################################################################################
+# Supporting Resoures
+################################################################################
+
+resource "aws_security_group" "additional" {
+  name_prefix = "${local.name}-additional"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = [
+      "10.0.0.0/8",
+      "172.16.0.0/12",
+      "192.168.0.0/16",
+    ]
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_key" "eks" {
+  description             = "EKS Secret Encryption Key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = local.default_tags
+}
+
+data "aws_ami" "eks_default" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${local.cluster_version}-v*"]
+  }
+}
+
+resource "tls_private_key" "this" {
+  algorithm = "RSA"
+}
+
+resource "aws_key_pair" "this" {
+  key_name   = "aws_key_${random_string.suffix.result}"
+  public_key = tls_private_key.this.public_key_openssh
+}
+
+resource "aws_kms_key" "ebs" {
+  description             = "Customer managed key to encrypt self managed node group volumes"
+  deletion_window_in_days = 7
+  policy                  = data.aws_iam_policy_document.ebs.json
+}
+
+# This policy is required for the KMS key used for EKS root volumes, so the cluster is allowed to enc/dec/attach encrypted EBS volumes
+data "aws_iam_policy_document" "ebs" {
+  # Copy of default KMS policy that lets you manage it
+  statement {
+    sid       = "Enable IAM User Permissions"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  # Required for EKS
+  statement {
+    sid = "Allow service-linked role use of the CMK"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", # required for the ASG to manage encrypted volumes for nodes
+        module.eks.cluster_iam_role_arn,                                                                                                            # required for the cluster / persistentvolume-controller to create encrypted PVCs
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow attachment of persistent resources"
+    actions   = ["kms:CreateGrant"]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling", # required for the ASG to manage encrypted volumes for nodes
+        module.eks.cluster_iam_role_arn,                                                                                                            # required for the cluster / persistentvolume-controller to create encrypted PVCs
+      ]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+}
+
+resource "aws_security_group" "remote_access" {
+  name_prefix = "${local.name}-remote-access"
+  description = "Allow remote SSH access"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/8"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_iam_policy" "node_additional" {
+  name        = "${local.name}-additional"
+  description = "Example usage of node additional policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ec2:Describe*",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = local.default_tags
+}
+
+
+resource "null_resource" "kubectl_config_update" {
+  depends_on = [
+    module.eks
+  ]
+  provisioner "local-exec" {
+    command = "aws eks --region $(terraform output -raw region) update-kubeconfig --name $(terraform output -raw cluster_name)"
+  }
+}

--- a/container-escape/terraform/aws/outputs.tf
+++ b/container-escape/terraform/aws/outputs.tf
@@ -1,0 +1,134 @@
+################################################################################
+# Cluster
+################################################################################
+output "cluster_name" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.eks.cluster_id
+}
+
+output "cluster_arn" {
+  description = "The Amazon Resource Name (ARN) of the cluster"
+  value       = module.eks.cluster_arn
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_endpoint" {
+  description = "Endpoint for your Kubernetes API server"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_id" {
+  description = "The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready"
+  value       = module.eks.cluster_id
+}
+
+output "cluster_platform_version" {
+  description = "Platform version for the cluster"
+  value       = module.eks.cluster_platform_version
+}
+
+output "cluster_status" {
+  description = "Status of the EKS cluster. One of `CREATING`, `ACTIVE`, `DELETING`, `FAILED`"
+  value       = module.eks.cluster_status
+}
+
+output "cluster_primary_security_group_id" {
+  description = "Cluster security group that was created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication. Referred to as 'Cluster security group' in the EKS console"
+  value       = module.eks.cluster_primary_security_group_id
+}
+
+################################################################################
+# Security Group
+################################################################################
+
+output "cluster_security_group_arn" {
+  description = "Amazon Resource Name (ARN) of the cluster security group"
+  value       = module.eks.cluster_security_group_arn
+}
+
+output "cluster_security_group_id" {
+  description = "ID of the cluster security group"
+  value       = module.eks.cluster_security_group_id
+}
+
+################################################################################
+# Node Security Group
+################################################################################
+
+output "node_security_group_arn" {
+  description = "Amazon Resource Name (ARN) of the node shared security group"
+  value       = module.eks.node_security_group_arn
+}
+
+output "node_security_group_id" {
+  description = "ID of the node shared security group"
+  value       = module.eks.node_security_group_id
+}
+
+################################################################################
+# IAM Role
+################################################################################
+
+output "cluster_iam_role_name" {
+  description = "IAM role name of the EKS cluster"
+  value       = module.eks.cluster_iam_role_name
+}
+
+output "cluster_iam_role_arn" {
+  description = "IAM role ARN of the EKS cluster"
+  value       = module.eks.cluster_iam_role_arn
+}
+
+output "cluster_iam_role_unique_id" {
+  description = "Stable and unique string identifying the IAM role"
+  value       = module.eks.cluster_iam_role_unique_id
+}
+
+################################################################################
+# EKS Managed Node Group
+################################################################################
+
+output "eks_managed_node_groups" {
+  description = "Map of attribute maps for all EKS managed node groups created"
+  value       = module.eks.eks_managed_node_groups
+}
+
+output "eks_managed_node_groups_autoscaling_group_names" {
+  description = "List of the autoscaling group names created by EKS managed node groups"
+  value       = module.eks.eks_managed_node_groups_autoscaling_group_names
+}
+
+
+################################################################################
+# Additional
+################################################################################
+
+output "aws_auth_configmap_yaml" {
+  description = "Formatted yaml output for base aws-auth configmap containing roles used in cluster node groups/fargate profiles"
+  value       = module.eks.aws_auth_configmap_yaml
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+################################################################################
+# Additional
+################################################################################
+
+# output "ecr_url" {
+#   value = aws_ecr_repository.dvwa.repository_url
+# }
+
+# output "ecr_id" {
+#   value = aws_ecr_repository.dvwa.registry_id
+# }
+
+output "kali_linux_public_ip" {
+  value = module.ec2_instance.public_ip
+}

--- a/container-escape/terraform/aws/provider.tf
+++ b/container-escape/terraform/aws/provider.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "docker" {}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_id]
+  }
+}

--- a/container-escape/terraform/aws/variables.tf
+++ b/container-escape/terraform/aws/variables.tf
@@ -1,0 +1,24 @@
+// VARIABLES
+
+variable "region" {
+  default     = "us-east-2"
+  description = "AWS Region"
+}
+
+variable "demo_name" {
+  description = "A name to be applied as a suffix to project resources"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  default     = "1.21"
+  description = "Kubernetes cluster version used with EKS"
+}
+
+variable "ssh_key" {
+  description = "SSH key associated with Kali Linux instance"
+}
+
+variable "publicIP" {
+  description = "Your home PublicIP to configure access to Kali Linux (if needed)"
+}

--- a/container-escape/terraform/aws/versions.tf
+++ b/container-escape/terraform/aws/versions.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.9.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1.0"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.2.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.10.0"
+    }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.16.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Terraform provisioning for DVWA. Running Terraform provides the following

- **AWS VPC**
- **AWS EKS Cluster** - 2 EKS managed worker nodes (m5.medium)
- **AWS EC2 Instance** - Kali Linux for ethical hacking
- **DVWA App** Deployed to EKS cluster



Signed-off-by: Scott Ford <scott@scottford.io>