### PR TITLE
Adds node scanning to container escape demo and more

### DIFF
--- a/container-escape/dvwa-example/dvwa-eks-deployment.yaml
+++ b/container-escape/dvwa-example/dvwa-eks-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: dvwa
-          image: 921877552404.dkr.ecr.us-east-2.amazonaws.com/dvwa-container-escape
+          image: public.ecr.aws/x6s5a8t7/dvwa:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80

--- a/container-escape/terraform/aws/.terraform.lock.hcl
+++ b/container-escape/terraform/aws/.terraform.lock.hcl
@@ -125,6 +125,13 @@ provider "registry.terraform.io/hashicorp/random" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:kMNyIFMdmGM/N98rV91adLyWeodKVCOaIRoNH8Xl5Ag=",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "3.3.0"
   constraints = ">= 3.0.0"

--- a/container-escape/terraform/aws/main.tf
+++ b/container-escape/terraform/aws/main.tf
@@ -192,7 +192,7 @@ module "eks" {
 
     # Complete
     complete = {
-      name            = "complete-eks-mng"
+      name            = "${var.demo_name}-eks-managed-nodes-${random_string.suffix.result}"
       use_name_prefix = true
 
       subnet_ids = module.vpc.public_subnets
@@ -229,7 +229,7 @@ module "eks" {
         max_unavailable_percentage = 50 # or set `max_unavailable`
       }
 
-      description = "EKS managed node group"
+      description = "${var.demo_name} EKS managed node group"
 
       ebs_optimized           = true
       vpc_security_group_ids  = [aws_security_group.additional.id]
@@ -254,7 +254,7 @@ module "eks" {
       create_iam_role          = true
       iam_role_name            = "${local.name}-iam-role"
       iam_role_use_name_prefix = false
-      iam_role_description     = "EKS managed node group role"
+      iam_role_description     = "${var.demo_name} EKS managed node group role"
       iam_role_tags = {
         Purpose = "Protector of the kubelet"
       }
@@ -266,9 +266,9 @@ module "eks" {
       ]
 
       create_security_group          = true
-      security_group_name            = "${local.name}-managed-worker-sg"
+      security_group_name            = "${var.demo_name}-managed-worker-sg-${random_string.suffix.result}"
       security_group_use_name_prefix = false
-      security_group_description     = "EKS managed node group security group"
+      security_group_description     = "${var.demo_name} EKS managed node group security group"
       security_group_rules = {
         phoneOut = {
           description = "Hello CloudFlare"
@@ -405,7 +405,7 @@ resource "aws_security_group" "kali_linux_access" {
 ################################################################################
 
 resource "aws_security_group" "additional" {
-  name_prefix = "${local.name}-additional"
+  name_prefix = "${var.demo_name}-eks-additional-sg-${random_string.suffix.result}"
   vpc_id      = module.vpc.vpc_id
 
   ingress {
@@ -416,7 +416,16 @@ resource "aws_security_group" "additional" {
       "10.0.0.0/8",
       "172.16.0.0/12",
       "192.168.0.0/16",
+      "${var.publicIP}/32"
     ]
+  }
+
+  ingress {
+    description       = "Cluster SG to Nodes"
+    protocol          = "-1"
+    from_port         = 0
+    to_port           = 0
+    security_groups   = [module.eks.cluster_security_group_id, module.eks.cluster_primary_security_group_id]
   }
 
   tags = local.default_tags
@@ -521,7 +530,7 @@ resource "aws_security_group" "remote_access" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/8"]
+    cidr_blocks = ["10.0.0.0/8", "${var.publicIP}/32"]
   }
 
   egress {

--- a/container-escape/terraform/aws/mondoo-config.yaml
+++ b/container-escape/terraform/aws/mondoo-config.yaml
@@ -11,4 +11,6 @@ spec:
   nodes:
     enable: true
   admission:
-    enable: false
+    enable: true
+    certificateProvisioning:
+      mode: cert-manager

--- a/container-escape/terraform/aws/outputs.tf
+++ b/container-escape/terraform/aws/outputs.tf
@@ -105,3 +105,14 @@ sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"
 
   EOT
 }
+
+
+output "cluster_security_group_id" {
+  description = "Cluster security group that was created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication. Referred to as 'Cluster security group' in the EKS console"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "cluster_primary_security_group_id" {
+  value = module.eks.cluster_primary_security_group_id
+  
+}

--- a/container-escape/terraform/mondoo-demo-177/aws-ec2.tf
+++ b/container-escape/terraform/mondoo-demo-177/aws-ec2.tf
@@ -43,11 +43,6 @@ EOF
 resource "aws_instance" "pass_example_4" {
   ami           = "ami-0279c3b3186e54acd"
   instance_type = "t2.micro"
-  user_data = <<EOF
-export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
-export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/A1AAAAA/bPxRfiCYAAAAAAAKEY
-export AWS_DEFAULT_REGION=us-east-1
-EOF
 
   metadata_options {
     http_tokens = "required"


### PR DESCRIPTION
This PR adds the following updates:

- Node scanning - Updates security groups for EKS managed nodes so `var.publicIP` is added. This means your home publicIP has access to remote scan nodes. Person demoing can now run `mondoo scan -t aws-ec2-ssm://ssm-user@<instanceId>`
- `dvwa-eks-deployment.yaml` - Updated example deployment manifest to use the public ECR image to demo `mondoo scan -t cr://public.ecr.aws/x6s5a8t7/dvwa:latest -o compact`
- Updates naming convention on cluster.
- Admission Controller - Updates security group for admission controller demo (coming soon)


Signed-off-by: Scott Ford <scott@scottford.io>