### PR TITLE
🐛 Fixes Amazon 2023 ami filter

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -6,7 +6,7 @@ data "aws_ami" "amazon2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-2023.1.2023*"]
+    values = ["al2023-ami-2023.1.2023*-kernel-6.1-x86_64"]
   }
 
   filter {


### PR DESCRIPTION
AMI filter for Amazon 2023 was pulling the wrong image. New image filter ensures we pull the latest x86_64 image. 