### PR TITLE
:broom: Add filter for amd64 for Ubuntu 22.04

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -423,7 +423,7 @@ data "aws_ami" "winserver2016_cis" {
 
   filter {
     name   = "name"
-    values = ["CIS Microsoft Windows Server 2019 Benchmark v2*Level 2*"]
+    values = ["CIS Microsoft Windows Server 2016 Benchmark*Level 2*"]
   }
 
   filter {

--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -186,6 +186,11 @@ data "aws_ami" "ubuntu2204_cis" {
   }
 
   filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
     name   = "virtualization-type"
     values = ["hvm"]
   }


### PR DESCRIPTION
adds a filter for `amd64` to Ubuntu 22.04 so we can stick to use `t2.medium` instances instead needing to use `t4g.medium` for ARM.