### PR TITLE
🎉 terraform template to depoly a proxy env for testing

### DIFF
--- a/aws/ec2-instance-proxy/README.md
+++ b/aws/ec2-instance-proxy/README.md
@@ -1,0 +1,48 @@
+# AWS EC2 INSTANCES
+
+This repository contains Terraform code for provisioning AWS EC2 instances for testing cnspec behind a squid proxy. The code creates the following:
+
+- AWS VPC
+- EC2 Security group for Linux with all ports open to your ip address
+- 2 EC instances
+  - One Debian12 is running the squid proxy (running port 3128)
+  - One Debian12 is allowed to ssh in and to communicate to the squid proxy (no direct internet access)
+
+## Prereqs
+
+- AWS Account
+- Terraform
+
+## Provision
+
+Example `terraform.tfvars`:
+
+```coffee
+prefix = "ec2-secops-test"
+
+aws_key_pair_name = "scottford"
+
+ssh_key = "~/.ssh/ssh-rsa"
+
+publicIP="1.1.1.1/32"
+
+linux_instance_type = "t2.medium"
+```
+
+```bash
+terraform init
+terraform plan -out tfplan.out
+terraform apply tfplan.out
+```
+
+## Test the squid proxy
+
+```bash
+curl -vk --proxy http://<private ip from proxy>:3128 https://google.de
+```
+
+Show the proxy connection in the log file
+
+```bash
+tail -f /var/log/squid/access.log
+```

--- a/aws/ec2-instance-proxy/amis.tf
+++ b/aws/ec2-instance-proxy/amis.tf
@@ -1,0 +1,18 @@
+////////////////////////////////
+// AMIs
+
+data "aws_ami" "debian12" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["debian-12-amd64-2023*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["136693071363"]
+}

--- a/aws/ec2-instance-proxy/main.tf
+++ b/aws/ec2-instance-proxy/main.tf
@@ -1,0 +1,131 @@
+resource "random_id" "instance_id" {
+  byte_length = 4
+}
+
+locals {
+  linux_proxy_data = <<-EOT
+    #!/bin/bash
+    sudo apt update
+    sudo apt install -y iptables curl squid dnsutils
+    sudo tee /etc/squid/squid.conf <<EOL
+    acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+    acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+    acl SSL_ports port 443
+    acl Safe_ports port 80		# http
+    acl Safe_ports port 443		# https
+    http_access deny !Safe_ports
+    http_access deny CONNECT !SSL_ports
+    http_access allow localhost manager
+    http_access deny manager
+    http_access allow localnet
+    http_access deny all
+    http_port 3128
+    coredump_dir /var/spool/squid
+    max_filedescriptors 4096
+    EOL
+
+    sudo systemctl restart squid
+    sudo systemctl enable squid 
+  EOT
+
+  linux_data = <<-EOT
+    #!/bin/bash
+    sudo apt update
+    sudo apt install -y iptables curl dnsutils
+    sudo iptables -A INPUT -i lo -j ACCEPT
+    sudo iptables -A OUTPUT -o lo -j ACCEPT
+    sudo iptables -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
+    sudo iptables -A OUTPUT -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT
+    sudo iptables -A OUTPUT -d 10.0.0.0/8 -j ACCEPT
+    sudo iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
+    sudo iptables -A OUTPUT -p udp --dport 53 -m state --state NEW,ESTABLISHED -j ACCEPT
+    sudo iptables -A INPUT  -p udp --sport 53 -m state --state ESTABLISHED     -j ACCEPT
+    sudo iptables -A OUTPUT -p tcp --dport 53 -m state --state NEW,ESTABLISHED -j ACCEPT
+    sudo iptables -A INPUT  -p tcp --sport 53 -m state --state ESTABLISHED     -j ACCEPT
+    sudo iptables -P OUTPUT DROP
+    sudo iptables -P INPUT DROP
+  EOT
+
+}
+
+////////////////////////////////
+// VPC Configuration
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.1.0"
+
+  name = "${var.prefix}-${random_id.instance_id.id}"
+  cidr = var.vpc_cidr
+
+  azs                = ["${var.region}a", "${var.region}b", "${var.region}c"]
+  private_subnets    = var.vpc_private_subnets
+  public_subnets     = var.vpc_public_subnets
+  enable_nat_gateway = var.vpc_enable_nat_gateway
+}
+
+////////////////////////////////
+// Linux Security Groups
+
+module "linux_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 4.3"
+
+  name        = "${var.prefix}-${random_id.instance_id.id}-linux-sg"
+  description = "Security group for linux instances"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      description = "Allow all from my ip"
+      cidr_blocks = "10.0.0.0/8,${var.publicIP}"
+    }
+  ]
+
+  egress_with_cidr_blocks = [
+    {
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      description = "User-service ports (ipv4)"
+      cidr_blocks = "0.0.0.0/0"
+    },
+  ]
+}
+
+// Debian 12 squid proxy
+
+module "debian12_proxy" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.2.1"
+
+  name                        = "${var.prefix}-debian12-proxy-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.debian12.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  user_data                   = base64encode(local.linux_proxy_data)
+  user_data_replace_on_change = true
+  associate_public_ip_address = true
+}
+
+// Debian 12
+
+module "debian12" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.2.1"
+
+  name                        = "${var.prefix}-debian12-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.debian12.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  user_data                   = base64encode(local.linux_data)
+  user_data_replace_on_change = true
+  associate_public_ip_address = true
+}

--- a/aws/ec2-instance-proxy/outputs.tf
+++ b/aws/ec2-instance-proxy/outputs.tf
@@ -1,0 +1,12 @@
+output "vpc-name" {
+  value = module.vpc.name
+}
+
+# debian12
+output "debian12" {
+  value = module.debian12.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian12.public_ip}"
+}
+
+output "debian12_proxy" {
+  value = module.debian12_proxy.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian12_proxy.public_ip}"
+}

--- a/aws/ec2-instance-proxy/providers.tf
+++ b/aws/ec2-instance-proxy/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = var.default_tags
+  }
+}

--- a/aws/ec2-instance-proxy/variables.tf
+++ b/aws/ec2-instance-proxy/variables.tf
@@ -1,0 +1,80 @@
+////////////////////////////////
+// AWS Credentials
+
+variable "aws_profile" {
+  default = "default"
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+////////////////////////////////
+// Global Settings
+
+variable "prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "mondoo"
+}
+
+variable "default_tags" {
+  description = "Tags to apply to resources created by VPC module"
+  type        = map(string)
+  default = {
+    Terraform   = "true"
+    Environment = "Test"
+  }
+}
+
+variable "mondoo_registration_token" {
+  description = "cnspec registration key"
+  type        = string
+  default     = ""
+}
+
+variable "ssh_key" {
+  description = "ssh rsa key to decrypt windows password"
+  type        = string
+  default     = ""
+}
+
+////////////////////////////////
+// VPC Settings
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "vpc_private_subnets" {
+  description = "Private subnets for VPC"
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "vpc_public_subnets" {
+  description = "Public subnets for VPC"
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "vpc_enable_nat_gateway" {
+  description = "Enable NAT gateway for VPC"
+  type        = bool
+  default     = true
+}
+
+////////////////////////////////
+// EC2 Settings
+
+variable "aws_key_pair_name" {}
+
+variable "linux_instance_type" {
+  default = "t2.micro"
+}
+
+variable "publicIP" {
+  description = "Your home PublicIP to configure access to ec2 instances"
+}


### PR DESCRIPTION
This terraform template deploys to Debian 12 vm. One is configured as a proxy and the other is installed with iptables to allow ssh inbound and outbound only DNS. That means it can only communicate via the proxy in the internet. 