### PR TITLE
:broom: Fix: no hard-coded project-id for service account in kms

### DIFF
--- a/hack-lab/container-escape/gcp/README.md
+++ b/hack-lab/container-escape/gcp/README.md
@@ -54,6 +54,16 @@ This folder contains Terraform automation code to provision the following:
   Essential Contacts Admin
   Owner
   ```
+
+- Create a `terraform.tfvars`` file with the following variables
+  ```
+  project_id = "your-project-3" #your gcp project string
+  region = "us-central1"
+  zone = "us-central1-a"
+  project_number = "" #your gcp project number
+  gke_version = "1.25.15-gke.1083000" # built on GKE 1.25, might need to be updated
+  ```
+
 - [gcloud CLI](https://cloud.google.com/sdk/docs/install)
 
   - make sure to install the [gke-gcloud-auth-plugin](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke), usually via the command:

--- a/hack-lab/container-escape/gcp/main.tf
+++ b/hack-lab/container-escape/gcp/main.tf
@@ -130,7 +130,7 @@ resource "google_compute_firewall" "default" {
 # GKE Cluster -> create aks cluster
 resource "google_container_cluster" "primary" {
   provider = google-beta
-  node_version = "1.25.9-gke.2300"
+  node_version = var.gke_version
   release_channel {
     channel = "STABLE"
   }
@@ -145,7 +145,7 @@ resource "google_container_cluster" "primary" {
   enable_tpu                  = false
   location                    = var.region
   logging_service             = "logging.googleapis.com/kubernetes"
-  min_master_version          = "1.25.9-gke.2300"
+  min_master_version          = var.gke_version
   monitoring_service          = "monitoring.googleapis.com/kubernetes"
   name                        = "lunalectric-gke-cluster-${random_string.suffix.result}"
   network                     = "lunalectric-gke-${random_string.suffix.result}"

--- a/hack-lab/container-escape/gcp/main.tf
+++ b/hack-lab/container-escape/gcp/main.tf
@@ -62,7 +62,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = [
-     "serviceAccount:lunalectric-${random_string.suffix.result}-node@manuel-development-3.iam.gserviceaccount.com",
+     "serviceAccount:lunalectric-${random_string.suffix.result}-node@${var.project_id}.iam.gserviceaccount.com",
      "serviceAccount:service-${var.project_number}@container-engine-robot.iam.gserviceaccount.com",
   ]
   depends_on = [

--- a/hack-lab/container-escape/gcp/variables.tf
+++ b/hack-lab/container-escape/gcp/variables.tf
@@ -15,3 +15,8 @@ variable "project_id" {
 variable "project_number" {
   type = string
 }
+
+variable "gke_version" {
+  type = string
+  default = "1.25.15-gke.1083000"
+}


### PR DESCRIPTION
Fixes:
- no more using a hardcoded project-id in KMS resource
- improved `Readme.md`
- added `gke_version` variable for easier updating GKE to newer versions