### PR TITLE
change nginx windows setup from windows 2016 to 2019

### DIFF
--- a/aws/ec2-instances/README.md
+++ b/aws/ec2-instances/README.md
@@ -81,7 +81,7 @@ This repository contains Terraform code for provisioning AWS EC2 instances for t
 | Windows 2022 CIS cnspec    | CIS Microsoft Windows Server 2022 Benchmark - Level 2 with latest cnspec | `create_windows2022_cis_cnspec` | [CIS Microsoft Windows Server 2022 Benchmark - Level 2](https://aws.amazon.com/marketplace/pp/prodview-lhbxwzmvsawbw?sr=0-19&ref_=beagle&applicationId=AWSMPContessa) |
 | Windows 2022 German        | Latest Windows 2022 Server German                                        | `create_windows2022_german`     | N/A                                                                                                                                                                   |
 | Windows 2022 Italian       | Latest Windows 2022 Server Italian                                       | `create_windows2022_italian`    | N/A                                                                                                                                                                   |
-| NGINX on Windows 2016 Server       | NGINX on Windows 2016 Server                                       | `create_nginx_win2016_cnspec`    | N/A                                                                                                                                                                   |
+| NGINX on Windows 2019 Server       | NGINX on Windows 2019 Server                                       | `create_nginx_win2019_cnspec`    | N/A                                                                                                                                                                   |
 
 ## Provision
 

--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -130,12 +130,12 @@ data "aws_ami" "nginx_rhel9_cis" {
   owners = ["679593333241"]
 }
 
-data "aws_ami" "nginx_win2016" {
+data "aws_ami" "nginx_win2019" {
   most_recent = true
 
   filter {
     name   = "name"
-    values = ["NGINX2016-*"]
+    values = ["NGINX2019-*"]
   }
 
   filter {

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -617,15 +617,15 @@ module "nginx_rhel9_cis_cnspec" {
   user_data_replace_on_change = true
 }
 
-// NGINX on Windows 2016
+// NGINX on Windows 2019
 
-module "nginx_win2016_cnspec" {
+module "nginx_win2019_cnspec" {
   source  = "terraform-aws-modules/ec2-instance/aws"
   version = "~> 5.2.1"
 
-  create                      = var.create_nginx_win2016_cnspec
-  name                        = "${var.prefix}-nginx-win2016-cnspec-${random_id.instance_id.id}"
-  ami                         = data.aws_ami.nginx_win2016.id
+  create                      = var.create_nginx_win2019_cnspec
+  name                        = "${var.prefix}-nginx-win2019-cnspec-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.nginx_win2019.id
   instance_type               = var.windows_instance_type
   vpc_security_group_ids      = [module.windows_sg.security_group_id]
   subnet_id                   = module.vpc.public_subnets[0]

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -297,7 +297,7 @@ output "windows2022_german" {
 output "windows2022_italian" {
   value = module.windows2022_italian.public_ip == null ? "" : "xfreerdp /u:Administrator /v:${module.windows2022_italian.public_ip}:3389 /h:2048 /w:2048 /p:'${var.windows_admin_password}'"
 }
-# nginx on windows 2016
-output "nginx_win2016_cnspec" {
-  value = module.nginx_win2016_cnspec.public_ip == null ? "" : "xfreerdp /u:Administrator /v:${module.nginx_win2016_cnspec.public_ip}:3389 /h:1200 /w:1920 /p:'${var.windows_admin_password}'\n(This will take a couple minutes to become available...)"
+# nginx on windows 2019
+output "nginx_win2019_cnspec" {
+  value = module.nginx_win2019_cnspec.public_ip == null ? "" : "xfreerdp /u:Administrator /v:${module.nginx_win2019_cnspec.public_ip}:3389 /h:1200 /w:1920 /p:'${var.windows_admin_password}'\n(This will take a couple minutes to become available...)"
 }

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -360,7 +360,7 @@ variable "create_windows2016_cis_cnspec" {
   default = false
 }
 
-variable "create_nginx_win2016_cnspec" {
+variable "create_nginx_win2019_cnspec" {
   default = false
 }
 


### PR DESCRIPTION
Switch the nginx setup from Windows 2016 to 2019 because the Windows 2016 images is no longer available