### PR TITLE
:broom: Removing old Debian10/RHEL7 samples

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -286,21 +286,21 @@ data "aws_ami" "debian10" {
   owners = ["136693071363"]
 }
 
-data "aws_ami" "debian10_cis" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["CIS Debian Linux 10*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["679593333241"]
-}
+#data "aws_ami" "debian10_cis" {
+#  most_recent = true
+#
+#  filter {
+#    name   = "name"
+#    values = ["CIS Debian Linux 10*"]
+#  }
+#
+#  filter {
+#    name   = "virtualization-type"
+#    values = ["hvm"]
+#  }
+#
+#  owners = ["679593333241"]
+#}
 
 
 

--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -97,21 +97,21 @@ data "aws_ami" "rhel7" {
   owners = ["309956199498"]
 }
 
-data "aws_ami" "rhel7_cis" {
-  most_recent = true
-
-  filter {
-    name   = "name"
-    values = ["CIS Red Hat Enterprise Linux 7*Level 2*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  owners = ["679593333241"]
-}
+#data "aws_ami" "rhel7_cis" {
+#  most_recent = true
+#
+#  filter {
+#    name   = "name"
+#    values = ["CIS Red Hat Enterprise Linux 7*Level 2*"]
+#  }
+#
+#  filter {
+#    name   = "virtualization-type"
+#    values = ["hvm"]
+#  }
+#
+#  owners = ["679593333241"]
+#}
 
 
 data "aws_ami" "nginx_rhel9_cis" {

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -192,21 +192,21 @@ module "amazon2_cis_cnspec" {
   user_data_replace_on_change = true
 }
 // Debian 10
-module "debian10_cis_cnspec" {
-  source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 5.2.1"
-
-  create                      = var.create_debian10_cis_cnspec
-  name                        = "${var.prefix}-debian10-cis-cnspec-${random_id.instance_id.id}"
-  ami                         = data.aws_ami.debian10_cis.id
-  instance_type               = var.linux_instance_type
-  vpc_security_group_ids      = [module.linux_sg.security_group_id]
-  subnet_id                   = module.vpc.public_subnets[0]
-  key_name                    = var.aws_key_pair_name
-  associate_public_ip_address = true
-  user_data                   = base64encode(local.linux_user_data)
-  user_data_replace_on_change = true
-}
+#module "debian10_cis_cnspec" {
+#  source  = "terraform-aws-modules/ec2-instance/aws"
+#  version = "~> 5.2.1"
+#
+#  create                      = var.create_debian10_cis_cnspec
+#  name                        = "${var.prefix}-debian10-cis-cnspec-${random_id.instance_id.id}"
+#  ami                         = data.aws_ami.debian10_cis.id
+#  instance_type               = var.linux_instance_type
+#  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+#  subnet_id                   = module.vpc.public_subnets[0]
+#  key_name                    = var.aws_key_pair_name
+#  associate_public_ip_address = true
+#  user_data                   = base64encode(local.linux_user_data)
+#  user_data_replace_on_change = true
+#}
 
 
 
@@ -553,36 +553,36 @@ module "rhel7_cnspec" {
   user_data_replace_on_change = true
 }
 
-module "rhel7_cis" {
-  source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 5.2.1"
+#module "rhel7_cis" {
+#  source  = "terraform-aws-modules/ec2-instance/aws"
+#  version = "~> 5.2.1"
+#
+#  create                      = var.create_rhel7_cis
+#  name                        = "${var.prefix}-rhel7-cis-${random_id.instance_id.id}"
+#  ami                         = data.aws_ami.rhel7_cis.id
+#  instance_type               = var.linux_instance_type
+#  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+#  subnet_id                   = module.vpc.public_subnets[0]
+#  key_name                    = var.aws_key_pair_name
+#  associate_public_ip_address = true
+#}
 
-  create                      = var.create_rhel7_cis
-  name                        = "${var.prefix}-rhel7-cis-${random_id.instance_id.id}"
-  ami                         = data.aws_ami.rhel7_cis.id
-  instance_type               = var.linux_instance_type
-  vpc_security_group_ids      = [module.linux_sg.security_group_id]
-  subnet_id                   = module.vpc.public_subnets[0]
-  key_name                    = var.aws_key_pair_name
-  associate_public_ip_address = true
-}
 
-
-module "rhel7_cis_cnspec" {
-  source  = "terraform-aws-modules/ec2-instance/aws"
-  version = "~> 5.2.1"
-
-  create                      = var.create_rhel7_cis_cnspec
-  name                        = "${var.prefix}-rhel7-cis-cnspec-${random_id.instance_id.id}"
-  ami                         = data.aws_ami.rhel7_cis.id
-  instance_type               = var.linux_instance_type
-  vpc_security_group_ids      = [module.linux_sg.security_group_id]
-  subnet_id                   = module.vpc.public_subnets[0]
-  key_name                    = var.aws_key_pair_name
-  associate_public_ip_address = true
-  user_data                   = base64encode(local.linux_user_data)
-  user_data_replace_on_change = true
-}
+#module "rhel7_cis_cnspec" {
+#  source  = "terraform-aws-modules/ec2-instance/aws"
+#  version = "~> 5.2.1"
+#
+#  create                      = var.create_rhel7_cis_cnspec
+#  name                        = "${var.prefix}-rhel7-cis-cnspec-${random_id.instance_id.id}"
+#  ami                         = data.aws_ami.rhel7_cis.id
+#  instance_type               = var.linux_instance_type
+#  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+#  subnet_id                   = module.vpc.public_subnets[0]
+#  key_name                    = var.aws_key_pair_name
+#  associate_public_ip_address = true
+#  user_data                   = base64encode(local.linux_user_data)
+#  user_data_replace_on_change = true
+#}
 
 
 // NGINX on RHEL 9 CIS

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -45,14 +45,14 @@ output "rhel7_cnspec" {
   value = module.rhel7_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cnspec.public_ip}"
 }
 
-
-output "rhel7_cis" {
-  value = module.rhel7_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cis.public_ip}"
-}
-
-output "rhel7_cis_cnspec" {
-  value = module.rhel7_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cis_cnspec.public_ip}"
-}
+# rhel7 cis
+#output "rhel7_cis" {
+#  value = module.rhel7_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cis.public_ip}"
+#}
+#
+#output "rhel7_cis_cnspec" {
+#  value = module.rhel7_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cis_cnspec.public_ip}"
+#}
 
 
 # rhel8
@@ -139,10 +139,10 @@ output "ubuntu2204_cis_cnspec_arm" {
 
 
 
-# debian10
-output "debian10_cis_cnspec" {
-  value = module.debian10_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10_cis_cnspec.public_ip}"
-}
+## debian10
+#output "debian10_cis_cnspec" {
+#  value = module.debian10_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10_cis_cnspec.public_ip}"
+#}
 
 # debian11
 output "debian11" {

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -188,13 +188,13 @@ variable "create_rhel7_cnspec" {
   default = false
 }
 
-variable "create_rhel7_cis" {
-  default = false
-}
+#variable "create_rhel7_cis" {
+#  default = false
+#}
 
-variable "create_rhel7_cis_cnspec" {
-  default = false
-}
+#variable "create_rhel7_cis_cnspec" {
+#  default = false
+#}
 
 variable "create_nginx_rhel9_cis" {
   default = false

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -208,13 +208,13 @@ variable "create_debian10" {
   default = false
 }
 
-variable "create_debian10_cnspec" {
-  default = false
-}
-
-variable "create_debian10_cis_cnspec" {
-  default = false
-}
+#variable "create_debian10_cnspec" {
+#  default = false
+#}
+#
+#variable "create_debian10_cis_cnspec" {
+#  default = false
+#}
 
 variable "create_debian11" {
   default = false


### PR DESCRIPTION
Removes deprecated AMIs