### PR TITLE
Revert rhel7 all & debian10 CIS

### DIFF
--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -193,6 +193,21 @@ module "amazon2_cis_cnspec" {
   user_data_replace_on_change = true
 }
 
+// Debian 10
+
+module "debian10" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_debian10
+  name                        = "${var.prefix}-debian10-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.debian10.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+}
 // Debian 11
 
 module "debian11" {

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -36,19 +36,6 @@ output "amazon2023_cnspec" {
   value = module.amazon2023_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.amazon2023_cnspec.public_ip}"
 }
 
-# rhel7
-output "rhel7_cis" {
-  value = module.rhel7_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.rhel7_cis.public_ip}"
-}
-
-output "rhel7_cis_cnspec" {
-  value = module.rhel7_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.rhel7_cis_cnspec.public_ip}"
-}
-
-output "rhel7_pass_private" {
-  value = module.rhel7_pass_private.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.rhel7_pass_private.public_ip}"
-}
-
 # rhel8
 output "rhel8" {
   value = module.rhel8.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel8.public_ip}"
@@ -148,19 +135,6 @@ output "ubuntu2404_arm64_cnspec_arm" {
 ## Ubuntu 24.04 amd64
 output "ubuntu2404" {
   value = module.ubuntu2404.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2404.public_ip}"
-}
-
-# debian10
-output "debian10" {
-  value = module.debian10.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10.public_ip}"
-}
-
-output "debian10_cis" {
-  value = module.debian10_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10_cis.public_ip}"
-}
-
-output "debian10_cis_cnspec" {
-  value = module.debian10_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10_cis_cnspec.public_ip}"
 }
 
 # debian11
@@ -320,9 +294,3 @@ output "windows2022_italian" {
 output "nginx_win2019_cnspec" {
   value = module.nginx_win2019_cnspec.public_ip == null ? "" : "xfreerdp /u:Administrator /v:${module.nginx_win2019_cnspec.public_ip}:3389 /h:1200 /w:1920 /p:'${var.windows_admin_password}'\n(This will take a couple minutes to become available...)"
 }
-# centos7
-output "centos7_hardened_community" {
-  value = module.centos7_hardened_community.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.centos7_hardened_community.public_ip}"
-}
-
-

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -137,6 +137,11 @@ output "ubuntu2404" {
   value = module.ubuntu2404.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2404.public_ip}"
 }
 
+# debian10
+output "debian10" {
+  value = module.debian10.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10.public_ip}"
+}
+
 # debian11
 output "debian11" {
   value = module.debian11.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian11.public_ip}"

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -192,22 +192,6 @@ variable "create_rhel8_cis_cnspec" {
   default = false
 }
 
-variable "create_centos7_hardened_community" {
-  default = false
-}
-
-variable "create_rhel7_pass_private" {
-  default = false
-}
-
-variable "create_rhel7_cis" {
-  default = false
-}
-
-variable "create_rhel7_cis_cnspec" {
-  default = false
-}
-
 variable "create_nginx_rhel9_cis" {
   default = false
 }
@@ -217,14 +201,6 @@ variable "create_nginx_rhel9_cis_cnspec" {
 }
 
 variable "create_debian10" {
-  default = false
-}
-
-variable "create_debian10_cnspec" {
-  default = false
-}
-
-variable "create_debian10_cis_cnspec" {
   default = false
 }
 


### PR DESCRIPTION
Revert RHEL7, CENTOS7 & Debian10 CIS references since they have been taken off AWS Marketplace