### PR TITLE
fix: remove hardcoded year from amazon2 AMI filter

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -27,7 +27,7 @@ data "aws_ami" "amazon2" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-kernel-5.10-hvm-2.0.2025*"]
+    values = ["amzn2-ami-kernel-5.10-hvm-*"]
   }
 
   filter {


### PR DESCRIPTION
## Problem

The Amazon Linux 2 AMI data source in `aws/ec2-instances/amis.tf` uses the filter:
```hcl
values = ["amzn2-ami-kernel-5.10-hvm-2.0.2025*"]
```

It is now 2026. This filter matches **zero** AMIs, causing `terraform plan` to fail with:
```
Error: Your query returned no results. Please change your search criteria and try again.

  with data.aws_ami.amazon2,
  on amis.tf line 25, in data "aws_ami" "amazon2":
```

## Fix

```diff
- values = ["amzn2-ami-kernel-5.10-hvm-2.0.2025*"]
+ values = ["amzn2-ami-kernel-5.10-hvm-*"]
```

The `most_recent = true` directive already selects the latest AMI, so the year prefix adds no value — it only creates an annual breakage point.

## Verification

Confirmed via AWS CLI that the broadened pattern returns current AMIs:
```
amzn2-ami-kernel-5.10-hvm-2.0.20260302.0-x86_64-gp2  ami-0a805324110a073bd  2026-02-26
```