### PR TITLE
fix: correct Ubuntu 18.04 AMI architecture filter

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -168,7 +168,7 @@ data "aws_ami" "ubuntu1804" {
 
   filter {
     name   = "name"
-    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-arm64-pro-server-*"]
+    values = ["ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-*"]
   }
 
   filter {


### PR DESCRIPTION
The `ubuntu1804` AMI data source filters for `arm64` images, but the module uses `var.linux_instance_type` which resolves to an x86_64 instance type (`t2.micro` default). This produces:

```
InvalidParameterValue: The architecture 'x86_64' of the specified instance type
does not match the architecture 'arm64' of the specified AMI
```

Canonical still publishes amd64 Ubuntu Pro 18.04 images (verified — latest is `ubuntu-pro-server/images/hvm-ssd/ubuntu-bionic-18.04-amd64-pro-server-20260213`).

**Change:** `arm64` → `amd64` in the AMI name filter.