### PR TITLE
feat: add RHEL 7 base and Debian 10 cnspec infrastructure

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -64,6 +64,23 @@ data "aws_ami" "amazon2_cis" {
   owners = ["679593333241"]
 }
 
+# RHEL 7
+data "aws_ami" "rhel7" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["RHEL-7.9_HVM-*-x86_64*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["309956199498"] // Red Hat
+}
+
 data "aws_ami" "rhel8" {
   most_recent = true
 

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -208,6 +208,22 @@ module "debian10" {
   key_name                    = var.aws_key_pair_name
   associate_public_ip_address = true
 }
+
+module "debian10_cnspec" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_debian10_cnspec
+  name                        = "${var.prefix}-debian10-cnspec-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.debian10.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+  user_data                   = base64encode(local.linux_user_data)
+  user_data_replace_on_change = true
+}
 // Debian 11
 
 module "debian11" {
@@ -769,6 +785,39 @@ module "rhel9_cis_cnspec" {
   user_data_replace_on_change = true
 }
 
+
+
+// Red Hat Linux 7
+
+module "rhel7" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_rhel7
+  name                        = "${var.prefix}-rhel7-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.rhel7.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+}
+
+module "rhel7_cnspec" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_rhel7_cnspec
+  name                        = "${var.prefix}-rhel7-cnspec-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.rhel7.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+  user_data                   = base64encode(local.linux_user_data)
+  user_data_replace_on_change = true
+}
 
 
 // Red Hat Linux 8

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -36,6 +36,15 @@ output "amazon2023_cnspec" {
   value = module.amazon2023_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.amazon2023_cnspec.public_ip}"
 }
 
+# rhel7
+output "rhel7" {
+  value = module.rhel7.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7.public_ip}"
+}
+
+output "rhel7_cnspec" {
+  value = module.rhel7_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel7_cnspec.public_ip}"
+}
+
 # rhel8
 output "rhel8" {
   value = module.rhel8.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel8.public_ip}"
@@ -139,6 +148,10 @@ output "ubuntu2404" {
 # debian10
 output "debian10" {
   value = module.debian10.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10.public_ip}"
+}
+
+output "debian10_cnspec" {
+  value = module.debian10_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} admin@${module.debian10_cnspec.public_ip}"
 }
 
 # debian11

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -176,6 +176,14 @@ variable "create_rhel9_cnspec" {
   default = false
 }
 
+variable "create_rhel7" {
+  default = false
+}
+
+variable "create_rhel7_cnspec" {
+  default = false
+}
+
 variable "create_rhel8" {
   default = false
 }
@@ -202,6 +210,10 @@ variable "create_rhel8_cis_cnspec" {
 // }
 
 variable "create_debian10" {
+  default = false
+}
+
+variable "create_debian10_cnspec" {
   default = false
 }
 


### PR DESCRIPTION
The CIS-hardened AMIs for RHEL 7 and Debian 10 were delisted from AWS Marketplace, but the base images are still available. This adds infrastructure so policies can still be tested against these OSes using the base images.

### RHEL 7
- AMI: `RHEL-7.9_HVM-*-x86_64*` (Red Hat official, owner `309956199498`)
- Modules: `rhel7` (base), `rhel7_cnspec` (with cnspec agent)
- Verified AMI exists: `RHEL-7.9_HVM-20240930-x86_64-0-Hourly2-GP3` (Oct 2024)

### Debian 10
- Module: `debian10_cnspec` (reuses existing `data.aws_ami.debian10` data source)
- Verified AMI exists: `debian-10-amd64-20240703-1797` (Jul 2024)