### PR TITLE
fix: ubuntu2204_cis_arm uses wrong instance type

### DIFF
--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -1063,7 +1063,7 @@ module "ubuntu2204_cis_arm" {
   create                      = var.create_ubuntu2204_cis_arm
   name                        = "${var.prefix}-ubuntu2204-cis-arm-${random_id.instance_id.id}"
   ami                         = data.aws_ami.ubuntu2204_cis_arm64.id
-  instance_type               = var.linux_instance_type
+  instance_type               = var.linux_instance_type_arm64
   vpc_security_group_ids      = [module.linux_sg.security_group_id]
   subnet_id                   = module.vpc.public_subnets[0]
   key_name                    = var.aws_key_pair_name


### PR DESCRIPTION
The `ubuntu2204_cis_arm` module used `var.linux_instance_type` (`t2.micro`, x86_64) but the AMI is arm64. Terraform apply fails with:

```
InvalidParameterValue: The architecture 'x86_64' of the specified instance type
does not match the architecture 'arm64' of the specified AMI.
```

Fix: use `var.linux_instance_type_arm64` (`t4g.medium`).