### PR TITLE
Add Ubuntu 20.04 CIS EC2 targets

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -212,6 +212,27 @@ data "aws_ami" "ubuntu2004" {
   owners = ["099720109477"] // Canonical
 }
 
+data "aws_ami" "ubuntu2004_cis" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CIS Ubuntu Linux 20.04 LTS Benchmark*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["679593333241"]
+}
+
 
 data "aws_ami" "ubuntu2204" {
   most_recent = true

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -992,6 +992,36 @@ module "ubuntu2004_cnspec" {
   user_data_replace_on_change = true
 }
 
+module "ubuntu2004_cis" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_ubuntu2004_cis
+  name                        = "${var.prefix}-ubuntu2004-cis-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.ubuntu2004_cis.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+}
+
+module "ubuntu2004_cis_cnspec" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_ubuntu2004_cis_cnspec
+  name                        = "${var.prefix}-ubuntu2004-cis-cnspec-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.ubuntu2004_cis.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+  user_data                   = base64encode(local.linux_user_data)
+  user_data_replace_on_change = true
+}
+
 
 // Ubuntu 22.04
 

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -106,6 +106,14 @@ output "ubuntu2004_cnspec" {
   value = module.ubuntu2004_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2004_cnspec.public_ip}"
 }
 
+output "ubuntu2004_cis" {
+  value = module.ubuntu2004_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2004_cis.public_ip}"
+}
+
+output "ubuntu2004_cis_cnspec" {
+  value = module.ubuntu2004_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2004_cis_cnspec.public_ip}"
+}
+
 
 # ubuntu2204
 output "ubuntu2204" {


### PR DESCRIPTION
Adds the missing Terraform wiring for the documented Ubuntu 20.04 CIS targets.

Includes:
- CIS Ubuntu 20.04 AMI lookup
- ubuntu2004_cis and ubuntu2004_cis_cnspec EC2 modules
- matching Terraform outputs for os-security-testing

Validation:
- terraform fmt -check aws/ec2-instances/amis.tf aws/ec2-instances/main.tf aws/ec2-instances/outputs.tf
- git diff --check