### PR TITLE
feat(azure-sentinelone): provision Windows VMs that register with SentinelOne

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -56,9 +56,11 @@ pmuench
 procs
 randomart
 rdm
+rdp
 rhel
 rkd
 secops
+sentinelone
 Thu
 timesync
 umxf
@@ -66,7 +68,9 @@ unminimize
 unnyfkbt
 upperdir
 vmss
+vnet
 webserver
+westeurope
 winget
 xdsp
 XVCJ

--- a/azure-sentinelone/.gitignore
+++ b/azure-sentinelone/.gitignore
@@ -1,0 +1,3 @@
+# SentinelOne agent installer (you supply it; not for version control)
+*.exe
+*.msi

--- a/azure-sentinelone/README.md
+++ b/azure-sentinelone/README.md
@@ -1,0 +1,92 @@
+# Windows VMs in Azure with SentinelOne
+
+Provisions four Windows VMs in a single Azure resource group and registers
+each one with an existing SentinelOne console via the agent's site token.
+
+## Platforms
+
+| VM                      | Variable                       |
+|-------------------------|--------------------------------|
+| Windows 10 Enterprise   | `create_windows10`             |
+| Windows 11 Enterprise   | `create_windows11`             |
+| Windows Server 2022     | `create_windows_server_2022`   |
+| Windows Server 2025     | `create_windows_server_2025`   |
+
+All four default to `true`. Set one to `false` to skip a VM. All VMs share one
+resource group, vnet, subnet and NSG.
+
+## Prerequisites
+
+- Azure subscription + `az` CLI logged in (`az login --use-device-code`)
+- Terraform >= 1.5
+- An existing SentinelOne console
+- A SentinelOne **scope token** (Sentinels → Agent management → Packages →
+  copy the "Scope Token" at the top of the page). Older docs call this a
+  "site token" — same value, the MSI install parameter is still
+  `SITE_TOKEN`.
+- The SentinelOne Windows agent `.msi`, downloaded locally. From the same
+  Packages page, download the Windows MSI manually through your logged-in
+  browser. Terraform will upload it to an Azure Storage Account it creates
+  and hand the VMs a read-only SAS URL — no manual blob hosting needed.
+
+## Configure
+
+Create `terraform.tfvars`:
+
+```hcl
+tenant_id       = "00000000-0000-0000-0000-000000000000"
+subscription_id = "00000000-0000-0000-0000-000000000000"
+
+publicIP = "1.2.3.4/32" # your egress IP for RDP
+
+sentinelone_site_token     = "eyJ1cmwi..."                              # from the S1 console
+sentinelone_installer_path = "./SentinelOneInstaller_windows_64bit.exe" # .msi or .exe both work
+
+# Optional overrides
+# location = "westeurope"
+# vm_size  = "Standard_D2s_v3"
+# windows_admin_password = "ChangeMe-very-long-pw!"  # default: generated random
+# create_windows10           = true
+# create_windows11           = true
+# create_windows_server_2022 = true
+# create_windows_server_2025 = true
+```
+
+The `windows_admin_password` defaults to a randomly-generated 24-char
+password — grab it with `terraform output -raw rdp_credentials` after
+apply.
+
+## Apply
+
+```bash
+az login --use-device-code
+terraform init --upgrade
+terraform plan -out plan.out
+terraform apply plan.out
+```
+
+## After apply
+
+```bash
+terraform output vm_summary
+terraform output -raw rdp_credentials   # shows username + password
+```
+
+The Custom Script Extension installs the agent on first boot. Logs land on
+the VM at:
+
+- `C:\sentinelone-install.log` (PowerShell transcript)
+- `C:\sentinelone-msi.log` (MSI verbose log)
+
+The new hosts should appear in the SentinelOne console within a few minutes
+of `terraform apply` finishing.
+
+## Find image SKUs
+
+```bash
+az vm image list --publisher MicrosoftWindowsDesktop --offer windows-11    --all -o table
+az vm image list --publisher MicrosoftWindowsServer  --offer WindowsServer --all -o table
+```
+
+Adjust the SKUs in `main.tf` (`local.vm_definitions`) if you want a different
+edition (e.g. non-Azure-edition server SKUs, or a different Win10/11 build).

--- a/azure-sentinelone/README.md
+++ b/azure-sentinelone/README.md
@@ -39,7 +39,7 @@ subscription_id = "00000000-0000-0000-0000-000000000000"
 
 publicIP = "1.2.3.4/32" # your egress IP for RDP
 
-sentinelone_site_token     = "eyJ1cmwi..."                              # from the S1 console
+sentinelone_site_token     = "REPLACE_WITH_S1_SCOPE_TOKEN"              # from the S1 console
 sentinelone_installer_path = "./SentinelOneInstaller_windows_64bit.exe" # .msi or .exe both work
 
 # Optional overrides

--- a/azure-sentinelone/main.tf
+++ b/azure-sentinelone/main.tf
@@ -1,0 +1,328 @@
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+# Generated only if var.windows_admin_password isn't set. Specials limited to
+# a safe set Azure accepts (no quotes, no backslash) so it can't break shell
+# escaping in commandToExecute or RDP login.
+resource "random_password" "admin" {
+  length           = 24
+  special          = true
+  override_special = "!#$%&*+-=?@"
+  min_lower        = 1
+  min_upper        = 1
+  min_numeric      = 1
+  min_special      = 1
+}
+
+locals {
+  resource_prefix        = "${var.prefix}-${random_string.suffix.result}"
+  windows_admin_password = coalesce(var.windows_admin_password, random_password.admin.result)
+
+  # All Windows VMs to create. Toggle individual VMs via the create_* variables.
+  # SKUs were chosen so they're publicly available on Azure Marketplace without
+  # extra licensing. Verify with:
+  #   az vm image list --publisher MicrosoftWindowsDesktop --offer windows-11 --all -o table
+  #   az vm image list --publisher MicrosoftWindowsServer  --offer WindowsServer  --all -o table
+  vm_definitions = {
+    win10 = {
+      enabled         = var.create_windows10
+      short_name      = "win10"
+      image_publisher = "MicrosoftWindowsDesktop"
+      image_offer     = "windows-10"
+      image_sku       = "win10-22h2-ent-g2"
+      patch_mode      = "AutomaticByOS"
+    }
+    win11 = {
+      enabled         = var.create_windows11
+      short_name      = "win11"
+      image_publisher = "MicrosoftWindowsDesktop"
+      image_offer     = "windows-11"
+      image_sku       = "win11-23h2-ent"
+      patch_mode      = "AutomaticByOS"
+    }
+    win2022 = {
+      enabled         = var.create_windows_server_2022
+      short_name      = "win2022"
+      image_publisher = "MicrosoftWindowsServer"
+      image_offer     = "WindowsServer"
+      image_sku       = "2022-datacenter-azure-edition"
+      # Azure Edition is hotpatch-compatible; Azure requires this patch mode.
+      patch_mode = "AutomaticByPlatform"
+    }
+    win2025 = {
+      enabled         = var.create_windows_server_2025
+      short_name      = "win2025"
+      image_publisher = "MicrosoftWindowsServer"
+      image_offer     = "WindowsServer"
+      image_sku       = "2025-datacenter-azure-edition"
+      # Azure Edition is hotpatch-compatible; Azure requires this patch mode.
+      patch_mode = "AutomaticByPlatform"
+    }
+  }
+
+  vms_to_create = { for k, v in local.vm_definitions : k => v if v.enabled }
+}
+
+# -----------------------------------------------------------------------------
+# Shared resource group + network
+# -----------------------------------------------------------------------------
+
+resource "azurerm_resource_group" "rg" {
+  name     = "rg-${local.resource_prefix}"
+  location = var.location
+  tags     = var.tags
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  name                = "vnet-${local.resource_prefix}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  address_space       = [var.vnet_address_space]
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "snet-${local.resource_prefix}-vms"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = [var.subnet_address_prefix]
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "nsg-${local.resource_prefix}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "allow_rdp" {
+  name                        = "AllowRDPFromAdmin"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+  priority                    = 200
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "3389"
+  source_address_prefix       = var.publicIP
+  destination_address_prefix  = "*"
+}
+
+resource "azurerm_subnet_network_security_group_association" "nsg_assoc" {
+  subnet_id                 = azurerm_subnet.subnet.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}
+
+# -----------------------------------------------------------------------------
+# Storage account for the SentinelOne installer
+#
+# We upload the .msi here and hand the VMs a read-only SAS URL. This avoids
+# the auth-required S1 console URL and gives us a stable URL across re-applies.
+# -----------------------------------------------------------------------------
+
+resource "random_string" "storage_suffix" {
+  length  = 10
+  special = false
+  upper   = false
+  numeric = true
+}
+
+resource "azurerm_storage_account" "installers" {
+  name                            = "s1msi${random_string.storage_suffix.result}"
+  resource_group_name             = azurerm_resource_group.rg.name
+  location                        = azurerm_resource_group.rg.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  tags                            = var.tags
+}
+
+resource "azurerm_storage_container" "installers" {
+  name                  = "installers"
+  storage_account_name  = azurerm_storage_account.installers.name
+  container_access_type = "private"
+}
+
+locals {
+  # The SentinelOne console hands you either an .msi or an .exe. Both work -
+  # the install script picks the right invocation based on this extension.
+  sentinelone_installer_extension = lower(reverse(split(".", var.sentinelone_installer_path))[0])
+}
+
+resource "azurerm_storage_blob" "sentinelone_msi" {
+  name                   = "SentinelInstaller.${local.sentinelone_installer_extension}"
+  storage_account_name   = azurerm_storage_account.installers.name
+  storage_container_name = azurerm_storage_container.installers.name
+  type                   = "Block"
+  source                 = var.sentinelone_installer_path
+  content_md5            = filemd5(var.sentinelone_installer_path)
+}
+
+# The install script lives in blob too. CSE downloads it via fileUris so
+# we don't have to inline its (multi-KB) contents into commandToExecute,
+# which is capped at ~8KB by cmd.exe. The script itself has no secrets.
+resource "azurerm_storage_blob" "install_script" {
+  name                   = "install-sentinelone.ps1"
+  storage_account_name   = azurerm_storage_account.installers.name
+  storage_container_name = azurerm_storage_container.installers.name
+  type                   = "Block"
+  source                 = "${path.module}/scripts/install-sentinelone.ps1"
+  content_md5            = filemd5("${path.module}/scripts/install-sentinelone.ps1")
+}
+
+# Service-level SAS scoped to a single blob object, read-only, valid for
+# ~5 years. Static dates keep the SAS stable across applies (no drift).
+data "azurerm_storage_account_sas" "installer_sas" {
+  connection_string = azurerm_storage_account.installers.primary_connection_string
+  https_only        = true
+
+  resource_types {
+    service   = false
+    container = false
+    object    = true
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  start  = "2025-01-01T00:00:00Z"
+  expiry = "2030-12-31T23:59:59Z"
+
+  permissions {
+    read    = true
+    write   = false
+    delete  = false
+    list    = false
+    add     = false
+    create  = false
+    update  = false
+    process = false
+    tag     = false
+    filter  = false
+  }
+}
+
+locals {
+  sentinelone_installer_url = "${azurerm_storage_blob.sentinelone_msi.url}${data.azurerm_storage_account_sas.installer_sas.sas}"
+  sentinelone_script_url    = "${azurerm_storage_blob.install_script.url}${data.azurerm_storage_account_sas.installer_sas.sas}"
+}
+
+# -----------------------------------------------------------------------------
+# Per-VM networking + compute
+# -----------------------------------------------------------------------------
+
+resource "azurerm_public_ip" "vm" {
+  for_each = local.vms_to_create
+
+  name                = "pip-${local.resource_prefix}-${each.value.short_name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  domain_name_label   = "${each.value.short_name}-${random_string.suffix.result}"
+  tags                = var.tags
+}
+
+resource "azurerm_network_interface" "vm" {
+  for_each = local.vms_to_create
+
+  name                = "nic-${local.resource_prefix}-${each.value.short_name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.vm[each.key].id
+  }
+
+  # Azure serializes writes against a subnet. Wait for the NSG association
+  # to finish so the 4 parallel NIC creates don't race against it (and each
+  # other) and get "Subnet not found" 400s.
+  depends_on = [azurerm_subnet_network_security_group_association.nsg_assoc]
+}
+
+resource "azurerm_windows_virtual_machine" "vm" {
+  for_each = local.vms_to_create
+
+  name                = "vm-${local.resource_prefix}-${each.value.short_name}"
+  computer_name       = substr(replace("${each.value.short_name}${random_string.suffix.result}", "-", ""), 0, 15)
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  size                = var.vm_size
+  admin_username      = var.windows_admin_username
+  admin_password      = local.windows_admin_password
+  tags                = var.tags
+
+  network_interface_ids = [azurerm_network_interface.vm[each.key].id]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = 128
+  }
+
+  source_image_reference {
+    publisher = each.value.image_publisher
+    offer     = each.value.image_offer
+    sku       = each.value.image_sku
+    version   = "latest"
+  }
+
+  provision_vm_agent       = true
+  enable_automatic_updates = true
+  patch_mode               = each.value.patch_mode
+}
+
+# -----------------------------------------------------------------------------
+# SentinelOne agent install via Custom Script Extension
+# -----------------------------------------------------------------------------
+
+resource "azurerm_virtual_machine_extension" "sentinelone" {
+  for_each = local.vms_to_create
+
+  name                       = "InstallSentinelOne"
+  virtual_machine_id         = azurerm_windows_virtual_machine.vm[each.key].id
+  publisher                  = "Microsoft.Compute"
+  type                       = "CustomScriptExtension"
+  type_handler_version       = "1.10"
+  auto_upgrade_minor_version = true
+  tags                       = var.tags
+
+  # fileUris: CSE downloads the install script to its working dir.
+  # commandToExecute: write secrets to C:\setup-config.json (base64-wrapped to
+  # avoid shell-escaping issues with tokens), then invoke the downloaded script.
+  # Both are in protected_settings so the SAS URLs and the script command line
+  # don't appear in `Get-AzVm` output.
+  protected_settings = jsonencode({
+    fileUris = [local.sentinelone_script_url]
+    commandToExecute = join("", [
+      "powershell -ExecutionPolicy Bypass -Command \"",
+      "[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('",
+      base64encode(jsonencode({
+        InstallerUrl       = local.sentinelone_installer_url
+        InstallerExtension = local.sentinelone_installer_extension
+        SiteToken          = var.sentinelone_site_token
+      })),
+      "')) | Set-Content C:\\setup-config.json -Encoding UTF8; ",
+      "& .\\install-sentinelone.ps1\""
+    ])
+  })
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "15m"
+  }
+}

--- a/azure-sentinelone/outputs.tf
+++ b/azure-sentinelone/outputs.tf
@@ -1,0 +1,26 @@
+output "resource_group_name" {
+  description = "Name of the resource group hosting all VMs"
+  value       = azurerm_resource_group.rg.name
+}
+
+output "vm_summary" {
+  description = "Summary per VM: hostname, public IP, FQDN"
+  value = {
+    for k, vm in azurerm_windows_virtual_machine.vm : k => {
+      name          = vm.name
+      computer_name = vm.computer_name
+      public_ip     = azurerm_public_ip.vm[k].ip_address
+      fqdn          = azurerm_public_ip.vm[k].fqdn
+      private_ip    = azurerm_network_interface.vm[k].private_ip_address
+    }
+  }
+}
+
+output "rdp_credentials" {
+  description = "Local admin credentials for RDP (sensitive). Password is randomly generated unless windows_admin_password is set."
+  sensitive   = true
+  value = {
+    username = var.windows_admin_username
+    password = local.windows_admin_password
+  }
+}

--- a/azure-sentinelone/providers.tf
+++ b/azure-sentinelone/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.85"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    virtual_machine {
+      delete_os_disk_on_deletion     = true
+      graceful_shutdown              = false
+      skip_shutdown_and_force_delete = true
+    }
+  }
+  tenant_id       = var.tenant_id
+  subscription_id = var.subscription_id
+}

--- a/azure-sentinelone/scripts/install-sentinelone.ps1
+++ b/azure-sentinelone/scripts/install-sentinelone.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Downloads and installs the SentinelOne Windows agent, registering it
+    with an existing SentinelOne console via a scope (site) token.
+.DESCRIPTION
+    Reads its config from C:\setup-config.json (written by the CSE
+    bootstrap commandToExecute). The script itself contains no secrets,
+    so it can be uploaded to Azure Blob as a plain artifact.
+
+    Expected JSON keys:
+      - InstallerUrl:       HTTPS URL of the installer (SAS-protected blob)
+      - InstallerExtension: "msi" or "exe" - selects install command
+      - SiteToken:          SentinelOne scope/site token
+#>
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+
+$logFile = 'C:\sentinelone-install.log'
+Start-Transcript -Path $logFile -Append
+
+Write-Host "=== SentinelOne agent install started: $(Get-Date) ==="
+
+$configPath = 'C:\setup-config.json'
+if (-not (Test-Path $configPath)) {
+    throw "Configuration file not found: $configPath"
+}
+
+$config = Get-Content $configPath -Raw | ConvertFrom-Json
+$installerUrl = $config.InstallerUrl
+$siteToken    = $config.SiteToken
+$extension    = ($config.InstallerExtension).ToLower()
+
+if ([string]::IsNullOrWhiteSpace($installerUrl)) {
+    throw 'InstallerUrl is empty - aborting.'
+}
+if ([string]::IsNullOrWhiteSpace($siteToken)) {
+    throw 'SiteToken is empty - aborting.'
+}
+if ($extension -ne 'msi' -and $extension -ne 'exe') {
+    throw "Unsupported InstallerExtension: '$extension' (expected 'msi' or 'exe')."
+}
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$installerPath = Join-Path $env:TEMP "SentinelInstaller.$extension"
+
+Write-Host "Downloading installer to $installerPath"
+Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
+Write-Host "Downloaded $((Get-Item $installerPath).Length) bytes"
+
+if ($extension -eq 'msi') {
+    $procArgs = @(
+        '/i', "`"$installerPath`"",
+        '/quiet',
+        '/norestart',
+        "SITE_TOKEN=$siteToken",
+        '/L*v', 'C:\sentinelone-msi.log'
+    )
+    Write-Host 'Running msiexec...'
+    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $procArgs -Wait -PassThru
+} else {
+    # SentinelOne EXE installer: -t <site_token> -q (silent)
+    $procArgs = @('-t', $siteToken, '-q')
+    Write-Host "Running $installerPath -t <REDACTED> -q"
+    $proc = Start-Process -FilePath $installerPath -ArgumentList $procArgs -Wait -PassThru
+}
+Write-Host "Installer exit code: $($proc.ExitCode)"
+
+# 0 = success, 3010 = success but reboot required.
+if ($proc.ExitCode -ne 0 -and $proc.ExitCode -ne 3010) {
+    throw "SentinelOne installation failed with exit code $($proc.ExitCode). See logs in C:\."
+}
+
+# Verify the agent service was registered and is starting. Give it a few
+# seconds since the EXE installer's process can return before the service
+# is fully registered.
+Start-Sleep -Seconds 10
+$service = Get-Service -Name 'SentinelAgent' -ErrorAction SilentlyContinue
+if ($null -eq $service) {
+    throw 'SentinelAgent service not found after install.'
+}
+Write-Host "SentinelAgent service status: $($service.Status)"
+
+Write-Host "=== SentinelOne agent install completed: $(Get-Date) ==="
+Stop-Transcript

--- a/azure-sentinelone/variables.tf
+++ b/azure-sentinelone/variables.tf
@@ -1,0 +1,111 @@
+variable "tenant_id" {
+  description = "Azure AD tenant ID"
+  type        = string
+}
+
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+}
+
+variable "prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = "mondoo-s1"
+}
+
+variable "location" {
+  description = "Azure region for all resources"
+  type        = string
+  default     = "westeurope"
+}
+
+variable "vnet_address_space" {
+  description = "Address space for the virtual network"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_address_prefix" {
+  description = "Address prefix for the VM subnet"
+  type        = string
+  default     = "10.0.1.0/24"
+}
+
+variable "publicIP" {
+  description = "Your public IP (CIDR) allowed to RDP into the VMs, e.g. '1.2.3.4/32'"
+  type        = string
+}
+
+variable "vm_size" {
+  description = "Azure VM size for all VMs"
+  type        = string
+  default     = "Standard_D2s_v3"
+}
+
+variable "windows_admin_username" {
+  description = "Local admin username for the Windows VMs"
+  type        = string
+  default     = "adminuser"
+}
+
+variable "windows_admin_password" {
+  description = "Local admin password for the Windows VMs. Leave null (the default) to generate a strong random password - retrieve it with `terraform output -raw rdp_credentials`. Override only if you need a specific value (>= 12 chars, Azure complexity rules)."
+  type        = string
+  sensitive   = true
+  default     = null
+
+  validation {
+    condition     = var.windows_admin_password == null || length(coalesce(var.windows_admin_password, "............")) >= 12
+    error_message = "If set, password must be at least 12 characters."
+  }
+}
+
+variable "sentinelone_site_token" {
+  description = "SentinelOne scope token (formerly 'site token') used to register agents with the existing console. Find it in Sentinels > Agent management > Packages > 'Scope Token'."
+  type        = string
+  sensitive   = true
+}
+
+variable "sentinelone_installer_path" {
+  description = "Local filesystem path to the SentinelOne Windows agent (.msi). Download it manually from the S1 console (Sentinels > Agent management > Packages) - Terraform uploads it to an Azure Storage Account and generates a read-only SAS URL the VMs use to fetch it."
+  type        = string
+
+  validation {
+    condition     = fileexists(var.sentinelone_installer_path)
+    error_message = "sentinelone_installer_path must point to an existing file."
+  }
+}
+
+variable "create_windows10" {
+  description = "Create the Windows 10 VM"
+  type        = bool
+  default     = true
+}
+
+variable "create_windows11" {
+  description = "Create the Windows 11 VM"
+  type        = bool
+  default     = true
+}
+
+variable "create_windows_server_2022" {
+  description = "Create the Windows Server 2022 VM"
+  type        = bool
+  default     = true
+}
+
+variable "create_windows_server_2025" {
+  description = "Create the Windows Server 2025 VM"
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to all resources"
+  type        = map(string)
+  default = {
+    Project   = "azure-sentinelone"
+    ManagedBy = "terraform"
+  }
+}


### PR DESCRIPTION
## Summary

New sample under `azure-sentinelone/` that provisions four Windows VMs
(Win10, Win11, Server 2022, Server 2025) in a single resource group and
registers each one with an existing SentinelOne console.

- **Single RG / VNet / Subnet / NSG**, four VMs via `for_each` over a map.
  Each VM individually toggleable via `create_*` variables.
- **Bring-your-own installer**: drop the SentinelOne `.msi` or `.exe`
  in the dir, point `sentinelone_installer_path` at it, Terraform creates
  a storage account, uploads the blob, generates a read-only SAS, and
  hands the URL to the CSE. No expiring console links to babysit.
- **Both installer formats supported**: install script detects file
  extension and dispatches `msiexec /i ... SITE_TOKEN=<t>` for MSI or
  `<exe> -t <t> -q` for the EXE installer.
- **Random admin password by default** (24 chars, Azure-safe specials).
  `windows_admin_password` var still accepts an override. Retrieve via
  `terraform output -raw rdp_credentials`.
- **CSE wiring**: bootstrap `commandToExecute` writes secrets to
  `C:\setup-config.json` from a small base64 blob, then runs the script
  downloaded via `fileUris` — keeps the command line well under
  `cmd.exe`'s 8KB cap.
- **Tested**: all four VMs successfully provisioned and registered the
  agent during development of this branch.

## Test plan

- [ ] `terraform init && terraform validate` in `azure-sentinelone/`
- [ ] `terraform plan` against a fresh subscription with a valid
      `terraform.tfvars` (tenant/sub IDs, publicIP, site token,
      installer path) — should show ~20 resources to add
- [ ] `terraform apply` — all four VMs reach Running, all four
      CSE extensions reach Succeeded
- [ ] Verify the four hosts appear in the SentinelOne console under
      Sentinels → Endpoints within ~5 minutes of apply
- [ ] `terraform destroy` — all resources removed cleanly
- [ ] Spot-check that `terraform.tfvars`, `terraform.tfstate*`,
      `.terraform/`, and the installer binary are excluded by gitignore