### PR TITLE
feat(azure-sentinelone): enable OpenSSH on Windows VMs

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,4 +1,5 @@
 AAD
+adminuser
 akic
 baf
 bru

--- a/azure-sentinelone/README.md
+++ b/azure-sentinelone/README.md
@@ -37,7 +37,7 @@ Create `terraform.tfvars`:
 tenant_id       = "00000000-0000-0000-0000-000000000000"
 subscription_id = "00000000-0000-0000-0000-000000000000"
 
-publicIP = "1.2.3.4/32" # your egress IP for RDP
+publicIP = "1.2.3.4/32" # your egress IP, allowed for RDP (3389) and SSH (22)
 
 sentinelone_site_token     = "REPLACE_WITH_S1_SCOPE_TOKEN"              # from the S1 console
 sentinelone_installer_path = "./SentinelOneInstaller_windows_64bit.exe" # .msi or .exe both work
@@ -80,6 +80,19 @@ the VM at:
 
 The new hosts should appear in the SentinelOne console within a few minutes
 of `terraform apply` finishing.
+
+## SSH access
+
+The install script enables Windows OpenSSH Server on every VM and the NSG
+opens port 22 to `var.publicIP`. Connect with the same local admin
+credentials used for RDP:
+
+```bash
+ssh adminuser@<public-ip-or-fqdn>
+```
+
+Password auth only (no key auth is configured). Get the password with
+`terraform output -raw rdp_credentials`.
 
 ## Find image SKUs
 

--- a/azure-sentinelone/main.tf
+++ b/azure-sentinelone/main.tf
@@ -112,6 +112,20 @@ resource "azurerm_network_security_rule" "allow_rdp" {
   destination_address_prefix  = "*"
 }
 
+resource "azurerm_network_security_rule" "allow_ssh" {
+  name                        = "AllowSSHFromAdmin"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+  priority                    = 210
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = var.publicIP
+  destination_address_prefix  = "*"
+}
+
 resource "azurerm_subnet_network_security_group_association" "nsg_assoc" {
   subnet_id                 = azurerm_subnet.subnet.id
   network_security_group_id = azurerm_network_security_group.nsg.id

--- a/azure-sentinelone/scripts/install-sentinelone.ps1
+++ b/azure-sentinelone/scripts/install-sentinelone.ps1
@@ -82,5 +82,39 @@ if ($null -eq $service) {
 }
 Write-Host "SentinelAgent service status: $($service.Status)"
 
+# OpenSSH Server: ships as a Windows Capability on Win10 1809+/Server 2019+.
+# Adding it auto-creates the "OpenSSH-Server-In-TCP" firewall rule; we just
+# need to enable + start sshd and make sure it survives reboots.
+Write-Host '=== Enabling OpenSSH Server ==='
+$sshCapability = Get-WindowsCapability -Online -Name 'OpenSSH.Server*' |
+    Select-Object -First 1
+if ($null -eq $sshCapability) {
+    Write-Warning 'OpenSSH.Server capability not found on this image - skipping SSH enablement.'
+} else {
+    if ($sshCapability.State -ne 'Installed') {
+        Write-Host "Installing $($sshCapability.Name)"
+        Add-WindowsCapability -Online -Name $sshCapability.Name | Out-Null
+    } else {
+        Write-Host "$($sshCapability.Name) already installed"
+    }
+
+    Set-Service -Name sshd -StartupType Automatic
+    Start-Service sshd
+    Write-Host "sshd service status: $((Get-Service sshd).Status)"
+
+    # The capability install adds OpenSSH-Server-In-TCP, but only for the
+    # profile the NIC was on at install time. Force it to all profiles so
+    # SSH stays reachable if Windows reclassifies the network later.
+    $fwRule = Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+    if ($null -eq $fwRule) {
+        New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
+            -DisplayName 'OpenSSH Server (sshd)' `
+            -Enabled True -Direction Inbound -Protocol TCP -Action Allow `
+            -LocalPort 22 -Profile Any | Out-Null
+    } else {
+        Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Enabled True -Profile Any
+    }
+}
+
 Write-Host "=== SentinelOne agent install completed: $(Get-Date) ==="
 Stop-Transcript


### PR DESCRIPTION
## Summary
- NSG rule opens port 22 to `var.publicIP` (same CIDR already used for RDP).
- Install script now adds the `OpenSSH.Server` Windows capability, enables/starts `sshd`, and pins the firewall rule to all profiles.
- README documents how to connect via `ssh adminuser@<host>` using the random admin password.

Password-auth only. No key auth configured.

## Test plan
- [ ] `terraform apply` on a fresh deploy, then `ssh adminuser@<fqdn>` to each of the four VMs and confirm a shell.
- [ ] Confirm `Get-Service sshd` shows `Running` and `Get-NetFirewallRule OpenSSH-Server-In-TCP` is `Enabled`.
- [ ] Confirm SentinelOne agent still registers (`Get-Service SentinelAgent`).