### PR TITLE
fix: repair rhel8 AMI filter to use standard RHEL 8 image

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -86,7 +86,7 @@ data "aws_ami" "rhel8" {
 
   filter {
     name   = "name"
-    values = ["RHEL_HA-8.6.0_HVM-*"]
+    values = ["RHEL-8.*_HVM-*-x86_64-*"]
   }
 
   filter {
@@ -94,7 +94,7 @@ data "aws_ami" "rhel8" {
     values = ["hvm"]
   }
 
-  owners = ["309956199498"]
+  owners = ["309956199498"] // Red Hat
 }
 
 data "aws_ami" "rhel8_cis" {


### PR DESCRIPTION
## Problem

The `rhel8` `aws_ami` data source in `aws/ec2-instances/amis.tf` filtered for `RHEL_HA-8.6.0_HVM-*` — the High Availability variant pinned to the 8.6.0 release. Red Hat has since deregistered those AMIs, so the lookup now fails with:

> Error: Your query returned no results. Please change your search criteria and try again.

Because Terraform evaluates every `aws_ami` data source on each `plan`, this single stale filter breaks `terraform plan`/`apply` for the entire configuration.

## Fix

Switch the filter to the standard RHEL 8 image glob `RHEL-8.*_HVM-*-x86_64-*`, consistent with the existing `rhel7` (`RHEL-7.9_HVM-*-x86_64*`) and `rhel9` (`RHEL-9.5*x86_64*`) definitions. Combined with `most_recent = true`, it always selects the latest available RHEL 8 minor and won't break again when a specific minor is deprecated.

`terraform fmt -check` passes.