### PR TITLE
Add CIS RHEL 10 Level 1 marketplace AMI target (rhel10_cis)

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -129,6 +129,22 @@ data "aws_ami" "rhel9_cis" {
   owners = ["679593333241"]
 }
 
+data "aws_ami" "rhel10_cis" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CIS Red Hat Enterprise Linux 10*Level 1*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["679593333241"]
+}
+
 // CIS NGINX on RHEL 9 - commented out as AMI is not available in marketplace
 // data "aws_ami" "nginx_rhel9_cis" {
 //   most_recent = true

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -768,6 +768,20 @@ module "rhel9_cis" {
   associate_public_ip_address = true
 }
 
+module "rhel10_cis" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_rhel10_cis
+  name                        = "${var.prefix}-rhel10-cis-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.rhel10_cis.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+}
+
 module "rhel9_cis_cnspec" {
   source  = "terraform-aws-modules/ec2-instance/aws"
   version = "~> 5.7.1"

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -75,6 +75,10 @@ output "rhel9_cis" {
   value = module.rhel9_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel9_cis.public_ip}"
 }
 
+output "rhel10_cis" {
+  value = module.rhel10_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel10_cis.public_ip}"
+}
+
 output "rhel9_cis_cnspec" {
   value = module.rhel9_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ec2-user@${module.rhel9_cis_cnspec.public_ip}"
 }

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -164,6 +164,10 @@ variable "create_rhel9_cis" {
   default = false
 }
 
+variable "create_rhel10_cis" {
+  default = false
+}
+
 variable "create_rhel9_cis_cnspec" {
   default = false
 }


### PR DESCRIPTION
### What

Adds the `rhel10_cis` EC2 target for the **CIS Hardened Image Level 1 on Red Hat Enterprise Linux 10** Marketplace AMI ([`prodview-gcddsiaexrf4i`](https://aws.amazon.com/marketplace/pp/prodview-gcddsiaexrf4i)), mirroring `rhel9_cis`:

- `variables.tf`: `create_rhel10_cis`
- `amis.tf`: `data.aws_ami.rhel10_cis` — name `CIS Red Hat Enterprise Linux 10*Level 1*`, owner `679593333241`, hvm
- `main.tf`: `module.rhel10_cis`
- `outputs.tf`: `rhel10_cis` ssh string (`ec2-user`)


