### PR TITLE
Add CIS Ubuntu 24.04 Level 1 marketplace AMI target (ubuntu2404_cis)

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -271,7 +271,7 @@ data "aws_ami" "ubuntu2404_cis" {
 
   filter {
     name   = "name"
-    values = ["CIS Ubuntu Linux 24.04*"]
+    values = ["CIS Ubuntu Linux 24.04*Level 1*"]
   }
 
   filter {

--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -266,6 +266,27 @@ data "aws_ami" "ubuntu2204_cis" {
   owners = ["679593333241"]
 }
 
+data "aws_ami" "ubuntu2404_cis" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["CIS Ubuntu Linux 24.04*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["679593333241"]
+}
+
 data "aws_ami" "ubuntu2204_cis_arm64" {
   most_recent = true
 

--- a/aws/ec2-instances/main.tf
+++ b/aws/ec2-instances/main.tf
@@ -1052,6 +1052,20 @@ module "ubuntu2204_cis" {
   associate_public_ip_address = true
 }
 
+module "ubuntu2404_cis" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "~> 5.7.1"
+
+  create                      = var.create_ubuntu2404_cis
+  name                        = "${var.prefix}-ubuntu2404-cis-${random_id.instance_id.id}"
+  ami                         = data.aws_ami.ubuntu2404_cis.id
+  instance_type               = var.linux_instance_type
+  vpc_security_group_ids      = [module.linux_sg.security_group_id]
+  subnet_id                   = module.vpc.public_subnets[0]
+  key_name                    = var.aws_key_pair_name
+  associate_public_ip_address = true
+}
+
 module "ubuntu2204_cis_cnspec" {
   source  = "terraform-aws-modules/ec2-instance/aws"
   version = "~> 5.7.1"

--- a/aws/ec2-instances/outputs.tf
+++ b/aws/ec2-instances/outputs.tf
@@ -124,6 +124,10 @@ output "ubuntu2204_cis" {
   value = module.ubuntu2204_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2204_cis.public_ip}"
 }
 
+output "ubuntu2404_cis" {
+  value = module.ubuntu2404_cis.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2404_cis.public_ip}"
+}
+
 output "ubuntu2204_cis_cnspec" {
   value = module.ubuntu2204_cis_cnspec.public_ip == null ? "" : "ssh -o StrictHostKeyChecking=no -i ~/.ssh/${var.aws_key_pair_name} ubuntu@${module.ubuntu2204_cis_cnspec.public_ip}"
 }

--- a/aws/ec2-instances/variables.tf
+++ b/aws/ec2-instances/variables.tf
@@ -123,6 +123,10 @@ variable "create_ubuntu2204_cis" {
   default = false
 }
 
+variable "create_ubuntu2404_cis" {
+  default = false
+}
+
 variable "create_ubuntu2204_cis_cnspec" {
   default = false
 }


### PR DESCRIPTION
### What

Adds the `ubuntu2404_cis` EC2 target for the **CIS Hardened Image Level 1 on Ubuntu Linux 24.04 LTS** Marketplace AMI, mirroring `ubuntu2204_cis`:

- `variables.tf`: `create_ubuntu2404_cis`
- `amis.tf`: `data.aws_ami.ubuntu2404_cis` — name `CIS Ubuntu Linux 24.04*Level 1*`, owner `679593333241`, x86_64/hvm
- `main.tf`: `module.ubuntu2404_cis`
- `outputs.tf`: `ubuntu2404_cis` ssh string (`ubuntu` user)

Note: filter is pinned to `*Level 1*` so it resolves the Level 1 AMI product specifically (the bare `CIS Ubuntu Linux 24.04*` could resolve a different listing). `terraform fmt` clean.

Consumed by mondoohq/os-security-testing#<os-pr>. Verified: AMI resolves (`ami-07980babe9c4037c3`); once subscribed, the instance provisioned, scanned, and was destroyed cleanly.
