### PR TITLE
Pin debian11_cis and ubuntu2204_cis to CIS Level 1 AMIs

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -249,8 +249,11 @@ data "aws_ami" "ubuntu2204_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Ubuntu Linux 22.04*"]
+    name = "name"
+    # Pin to the Level 1 server image. The bare "CIS Ubuntu Linux 22.04*"
+    # wildcard let most_recent match non-Level-1 variants (STIG / Level 2 /
+    # container) that scan well below Level 1 (see os-security-testing#123).
+    values = ["CIS Ubuntu Linux 22.04*Level 1*"]
   }
 
   filter {
@@ -387,8 +390,11 @@ data "aws_ami" "debian11_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Debian Linux 11*"]
+    name = "name"
+    # Pin to the Level 1 server image. The bare "CIS Debian Linux 11*"
+    # wildcard let most_recent match non-Level-1 variants (STIG / Level 2 /
+    # container) that scan well below Level 1 (see os-security-testing#123).
+    values = ["CIS Debian Linux 11*Level 1*"]
   }
 
   filter {


### PR DESCRIPTION
## Summary

`data.aws_ami.debian11_cis` and `data.aws_ami.ubuntu2204_cis` used a bare `"CIS <OS>*"` name filter with `most_recent = true`. CIS publishes several Marketplace AMI families under that prefix — **Level 1**, **Level 2**, **STIG**, and **container** images — so `most_recent` can resolve to a non-Level-1 variant.

In `mondoohq/os-security-testing` weekly CIS Level 1 scans, these two targets came back markedly **under-hardened** vs their peers:

| target | filter | score |
|---|---|---|
| debian11_cis | `CIS Debian Linux 11*` | **63.5%** |
| ubuntu2204_cis (x86) | `CIS Ubuntu Linux 22.04*` | **64.6%** |
| ubuntu2204_cis_arm (same OS/policy) | `CIS Ubuntu Linux 22.04*ARM*` | 90.5% |
| debian13_cis / amazon2_cis / rhel10_cis | (resolve to L1) | 99% / ~96% / 97% |

The x86-vs-arm gap (64.6% vs 90.5%, identical except the arch + name filter) confirms the bare wildcard is selecting the wrong image, not a policy/scanner artifact.

## Change

Pin both name filters to `*Level 1*`, matching the convention already used by `ubuntu2404_cis` (`"CIS Ubuntu Linux 24.04*Level 1*"`), so the lookup selects the Level 1 server image and excludes STIG / Level 2 variants.

```hcl
- values = ["CIS Debian Linux 11*"]
+ values = ["CIS Debian Linux 11*Level 1*"]

- values = ["CIS Ubuntu Linux 22.04*"]
+ values = ["CIS Ubuntu Linux 22.04*Level 1*"]
```

## ⚠️ Verify before merge

I could not run `terraform plan` / `aws ec2 describe-images` (no AWS access in this environment). Please confirm each filter resolves to the intended Level 1 AMI:

```sh
aws ec2 describe-images --owners 679593333241 \
  --filters "Name=name,Values=CIS Debian Linux 11*Level 1*" \
  --query 'Images[].Name' --output text
aws ec2 describe-images --owners 679593333241 \
  --filters "Name=name,Values=CIS Ubuntu Linux 22.04*Level 1*" \
  --query 'Images[].Name' --output text
```

If CIS's AMI **Name** field does not contain the literal `Level 1`, adjust the filter accordingly (e.g. pin by `product-code` or `image-id`). `terraform fmt` clean.

## Related

- Companion baseline refresh: mondoohq/os-security-testing#123 (refreshes the 7 genuinely-hardened `_cis` baselines; intentionally leaves debian11_cis/ubuntu2204_cis for this AMI pin).
