### PR TITLE
Pin remaining CIS _cis AMIs to Level 1 (deterministic selection)

### DIFF
--- a/aws/ec2-instances/amis.tf
+++ b/aws/ec2-instances/amis.tf
@@ -425,8 +425,10 @@ data "aws_ami" "debian12_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Debian Linux 12*"]
+    name = "name"
+    # Pin to the Level 1 server image; most_recent over the bare wildcard can
+    # select STIG/Level 2 variants (see os-security-testing#123).
+    values = ["CIS Debian Linux 12*Level 1*"]
   }
 
   filter {
@@ -457,8 +459,10 @@ data "aws_ami" "debian13_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Debian Linux 13*"]
+    name = "name"
+    # Pin to the Level 1 server image; most_recent over the bare wildcard can
+    # select STIG/Level 2 variants (see os-security-testing#123).
+    values = ["CIS Debian Linux 13*Level 1*"]
   }
 
   filter {
@@ -531,8 +535,10 @@ data "aws_ami" "oracle8_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Oracle Linux 8 Benchmark*"]
+    name = "name"
+    # Pin to the Level 1 server image; the bare wildcard also matches the
+    # Level 2 image, which most_recent can select (see os-security-testing#123).
+    values = ["CIS Oracle Linux 8 Benchmark*Level 1*"]
   }
 
   filter {
@@ -564,8 +570,10 @@ data "aws_ami" "oracle9_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Oracle Linux 9 Benchmark*"]
+    name = "name"
+    # Pin to the Level 1 server image; most_recent over the bare wildcard can
+    # select STIG/Level 2 variants (see os-security-testing#123).
+    values = ["CIS Oracle Linux 9 Benchmark*Level 1*"]
   }
 
   filter {
@@ -684,8 +692,10 @@ data "aws_ami" "rocky9_cis" {
   most_recent = true
 
   filter {
-    name   = "name"
-    values = ["CIS Rocky Linux 9 Benchmark*"]
+    name = "name"
+    # Pin to the Level 1 server image; most_recent over the bare wildcard can
+    # select STIG/Level 2 variants (see os-security-testing#123).
+    values = ["CIS Rocky Linux 9 Benchmark*Level 1*"]
   }
 
   filter {


### PR DESCRIPTION
## Summary

Follow-up to #116. Five more `_cis` AMI lookups use **bare** `name` filters with `most_recent = true`. CIS publishes multiple hardened-image families per OS (**Level 1**, **Level 2**, **STIG**) and rebuilds them monthly, so `most_recent` can silently select the wrong variant — the exact defect that made `debian11_cis`/`ubuntu2204_cis` scan the **STIG** image and fail the CIS Level 1 baseline.

## Verified against AWS

`aws ec2 describe-images --owners 679593333241` (us-east-1). Each pinned filter resolves to the intended Level 1 image:

| target | before | resolves to (after) |
|---|---|---|
| debian12_cis | `CIS Debian Linux 12*` | `CIS Debian Linux 12 Benchmark - Level 1 - v06` |
| debian13_cis | `CIS Debian Linux 13*` | `CIS Debian Linux 13 Benchmark - Level 1 - v06` |
| oracle8_cis | `CIS Oracle Linux 8 Benchmark*` | `CIS Oracle Linux 8 Benchmark - Level 1 - v02` |
| oracle9_cis | `CIS Oracle Linux 9 Benchmark*` | `CIS Oracle Linux 9 Benchmark - Level 1 - v02` |
| rocky9_cis | `CIS Rocky Linux 9 Benchmark*` | `CIS Rocky Linux 9 Benchmark - Level 1 - v06` |

**Behavior-preserving today** — each already resolves to Level 1, so no live scan changes — but it removes the latent drift.

⚠️ **`oracle8_cis` is the urgent one**: its bare filter *already* matches the **Level 2** image (`CIS Oracle Linux 8 Benchmark - Level 2 - v02`, published ~3 min before the L1 build), so it is one monthly rebuild away from flipping to L2.

Not touched: `ubuntu2204_cis_arm` (`*ARM*` only matches the L1 ARM image today), `suse15_cis` (`*Level*` only matches L1), and the `*Level 2*`/`*Level 1*` filters that are already level-pinned.

`terraform fmt` clean.
